### PR TITLE
Add App/Screen defaults, and handle enum reserved names

### DIFF
--- a/src/PAModel/ControlTemplates/ControlTemplateParser.cs
+++ b/src/PAModel/ControlTemplates/ControlTemplateParser.cs
@@ -2,15 +2,16 @@
 // Licensed under the MIT License.
 
 using Microsoft.AppMagic.Authoring.Persistence;
-using System;
-using System.Collections.Generic;
-using System.Text;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 
 namespace Microsoft.PowerPlatform.Formulas.Tools.ControlTemplates
 {
     internal class ControlTemplateParser
     {
+        internal static Regex _reservedIdentifierRegex = new Regex(@"%([a-zA-Z]*)\.RESERVED%");
+
+
         internal static bool TryParseTemplate(string templateString, AppType type, out ControlTemplate template, out string name)
         {
             template = null;
@@ -75,7 +76,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.ControlTemplates
 
             var defaultOverride = includeProperty.Attribute(ControlMetadataXNames.DefaultValueAttribute);
             if (defaultOverride != null)
-                template.InputDefaults.Add(propertyName, defaultOverride.Value);
+                template.InputDefaults.Add(propertyName, UnescapeReservedName(defaultOverride.Value));
             else 
                 template.InputDefaults.Add(propertyName, CommonControlProperties.Instance.GetDefaultValue(propertyName, type));
         }
@@ -93,18 +94,22 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.ControlTemplates
 
             var defaultValueAttrib = property.Attribute(ControlMetadataXNames.DefaultValueAttribute);
             if (defaultValueAttrib != null)
-                defaultValue = defaultValueAttrib.Value;
+                defaultValue = UnescapeReservedName(defaultValueAttrib.Value);
 
             var phoneDefaultValueAttrib = property.Attribute(ControlMetadataXNames.PhoneDefaultValueAttribute);
             if (phoneDefaultValueAttrib != null)
-                phoneDefaultValue = phoneDefaultValueAttrib.Value;
+                phoneDefaultValue = UnescapeReservedName(phoneDefaultValueAttrib.Value);
 
             var webDefaultValueAttrib = property.Attribute(ControlMetadataXNames.WebDefaultValueAttribute);
             if (webDefaultValueAttrib != null)
-                webDefaultValue = webDefaultValueAttrib.Value;
+                webDefaultValue = UnescapeReservedName(webDefaultValueAttrib.Value);
 
             return new ControlProperty(nameAttr.Value, defaultValue, phoneDefaultValue, webDefaultValue);
         }
 
+        private static string UnescapeReservedName(string expression)
+        {
+            return _reservedIdentifierRegex.Replace(expression, "$1");
+        }
     }
 }

--- a/src/PAModel/ControlTemplates/GlobalTemplates.cs
+++ b/src/PAModel/ControlTemplates/GlobalTemplates.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.AppMagic.Authoring.Persistence;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.PowerPlatform.Formulas.Tools.ControlTemplates
+{
+    internal class GlobalTemplates
+    {
+        public static void AddCodeOnlyTemplates(Dictionary<string, ControlTemplate> templates, AppType type)
+        {
+            templates.Add("appinfo", CreateAppInfoTemplate(type));
+            templates.Add("screen", CreateScreenTemplate(type));
+        }
+
+        private static ControlTemplate CreateAppInfoTemplate(AppType type)
+        {
+            var template = new ControlTemplate("appinfo", "1.0", "http://microsoft.com/appmagic/appinfo");
+            template.InputDefaults.Add("MinScreenHeight", type == AppType.Phone ? "640" : "320");
+            template.InputDefaults.Add("MinScreenWidth", type == AppType.Phone ? "640" : "320");
+            template.InputDefaults.Add("ConfirmExit", "false");
+            template.InputDefaults.Add("SizeBreakpoints", type == AppType.Phone ? "[1200, 1800, 2400]" : "[600, 900, 1200]");
+            return template;
+        }
+
+        private static ControlTemplate CreateScreenTemplate(AppType type)
+        {
+            var template = new ControlTemplate("screen", "1.0", "http://microsoft.com/appmagic/screen");
+            template.InputDefaults.Add("Fill", "RGBA(255, 255, 255, 1)");
+            template.InputDefaults.Add("Height", "Max(App.Height, App.MinScreenHeight)");
+            template.InputDefaults.Add("Width", "Max(App.Width, App.MinScreenWidth)");
+            template.InputDefaults.Add("Size", "1 + CountRows(App.SizeBreakpoints) - CountIf(App.SizeBreakpoints, Value >= Self.Width)");
+            template.InputDefaults.Add("Orientation", "If(Self.Width < Self.Height, Layout.Vertical, Layout.Horizontal)");
+            template.InputDefaults.Add("LoadingSpinner", "LoadingSpinner.None");
+            template.InputDefaults.Add("LoadingSpinnerColor", "RGBA(0, 51, 102, 1)");
+            template.InputDefaults.Add("ImagePosition", "ImagePosition.Fit");
+            return template;
+        }
+
+    }
+}

--- a/src/PAModel/Serializers/SourceSerializer.cs
+++ b/src/PAModel/Serializers/SourceSerializer.cs
@@ -157,6 +157,9 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 templateList.Add(new TemplatesJson.TemplateJson() { Name = templateName, Template = xmlContents, Version = parsedTemplate.Version });
             }
 
+            // Also add Screen and App templates (not xml, constructed in code on the server)
+            GlobalTemplates.AddCodeOnlyTemplates(loadedTemplates, app._properties.DocumentAppType);
+
             app._templates = new TemplatesJson() { UsedTemplates = templateList.ToArray() };
         }
 
@@ -303,6 +306,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                     templateDefaults.Add(name, parsedTemplate);
             }
 
+            // Also add Screen and App templates (not xml, constructed in code on the server)
+            GlobalTemplates.AddCodeOnlyTemplates(templateDefaults, app._properties.DocumentAppType);
 
             var templates = new Dictionary<string, ControlInfoJson.Template>();
 


### PR DESCRIPTION
Unescapes enum reserved names in templates, adds defaults for app/screen
This can lead to a control being completely empty in .pa files, might be something to think about.