### PR TITLE
Use TemplateDisplayName if present for PCF controls

### DIFF
--- a/src/PAModel/EditorState/TemplateStore.cs
+++ b/src/PAModel/EditorState/TemplateStore.cs
@@ -16,10 +16,11 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.EditorState
 
         public bool AddTemplate(ControlInfoJson.Template template)
         {
-            if (Contents.ContainsKey(template.Name))
+            var name = template.TemplateDisplayName ?? template.Name;
+            if (Contents.ContainsKey(name))
                 return false;
 
-            Contents.Add(template.Name, template);
+            Contents.Add(name, template);
             return true;
         }
 

--- a/src/PAModel/IR/IRStateHelpers.cs
+++ b/src/PAModel/IR/IRStateHelpers.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                     Identifier = control.Name,
                     Kind = new TemplateNode()
                     {
-                        TemplateName = control.Template.Name,
+                        TemplateName = control.Template.TemplateDisplayName ?? control.Template.Name,
                         OptionalVariant = string.IsNullOrEmpty(control.VariantName) ? null : control.VariantName
                     }
                 },

--- a/src/PAModel/Schemas/adhoc/Control.cs
+++ b/src/PAModel/Schemas/adhoc/Control.cs
@@ -46,6 +46,10 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             public bool? IsComponentDefinition { get; set; }
             public ComponentDefinitionInfoJson ComponentDefinitionInfo { get; set; }
 
+
+            // Present on PCF
+            public string TemplateDisplayName { get; set; } = null;
+
             [JsonExtensionData]
             public Dictionary<string, object> ExtensionData { get; set; }
 
@@ -55,6 +59,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             {
                 Id = other.Id;
                 Name = other.Name;
+                TemplateDisplayName = other.TemplateDisplayName;
                 Version = other.Version;
                 LastModifiedTimestamp = other.LastModifiedTimestamp;
                 IsComponentDefinition = other.IsComponentDefinition;

--- a/src/PAModel/Serializers/MsAppSerializer.cs
+++ b/src/PAModel/Serializers/MsAppSerializer.cs
@@ -213,7 +213,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             app._unknownFiles.Add(entry.Name, entry);
         }
 
-
         // Write back out to a msapp file. 
         public static void SaveAsMsApp(this CanvasDocument app, string fullpathToMsApp)
         {


### PR DESCRIPTION
Improves from 
```
//! PAFile:0.1
control Screen1 : screen
    control _slider1 : 'jms_SampleNamespace.TSLinearInputComponent(fd140aaf-4df4-11dd-bd17-0019b9312238)'
        X = 392
        Y = 100
        Width = 512
        Height = 142
```
to 
```
//! PAFile:0.1
control Screen1 : screen
    control _slider1 : TSLinearInputComponent_Display_Key
        X = 392
        Y = 100
        Width = 512
        Height = 142
```