### PR TITLE
Clean up /Src folder contents

### DIFF
--- a/src/PAModel/CanvasDocument.cs
+++ b/src/PAModel/CanvasDocument.cs
@@ -58,10 +58,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         // Save for roundtripping.
         internal Entropy _entropy = new Entropy();
 
-        // Information about data components. 
-        // TemplateGuid --> Info
-        internal Dictionary<string, MinDataComponentManifest> _dataComponents = new Dictionary<string, MinDataComponentManifest>();
-
         // checksum from existin msapp. 
         internal ChecksumJson _checksum;
 

--- a/src/PAModel/EditorState/CombinedTemplateState.cs
+++ b/src/PAModel/EditorState/CombinedTemplateState.cs
@@ -38,6 +38,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.EditorState
         // Present on PCF
         public string TemplateDisplayName { get; set; } = null;
 
+        public ComponentManifest ComponentManifest { get; set; } = null;
+
         [JsonExtensionData]
         public Dictionary<string, object> ExtensionData { get; set; }
 

--- a/src/PAModel/Schemas/adhoc/ComponentsMetadataJson.cs
+++ b/src/PAModel/Schemas/adhoc/ComponentsMetadataJson.cs
@@ -13,7 +13,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
     // A minimal representation of the data component manifest
     // This is client-only. 
     // $$$ - can we get this from the PA file directly?
-    internal class MinDataComponentManifest
+    internal class ComponentManifest
     {
         public string Name { get; set; } // a name, "Component1"
         public string TemplateGuid { get; set; } // a guid 
@@ -49,9 +49,9 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         }
 
         // A component will always have this. 
-        internal static MinDataComponentManifest Create(ComponentsMetadataJson.Entry x)
+        internal static ComponentManifest Create(ComponentsMetadataJson.Entry x)
         {
-            var dc = new MinDataComponentManifest
+            var dc = new ComponentManifest
             {
                 Name = x.Name,
                 ExtensionData = x.ExtensionData

--- a/src/PAModel/Serializers/SourceSerializer.cs
+++ b/src/PAModel/Serializers/SourceSerializer.cs
@@ -218,27 +218,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
         private static void LoadSourceFiles(CanvasDocument app, DirectoryReader directory, Dictionary<string, ControlTemplate> templateDefaults, ErrorContainer errors)
         {
-            foreach (var file in directory.EnumerateFiles(CodeDir, "*.json"))
-            {
-                if (file.Kind == FileKind.Templates)
-                {
-                    // Maybe we can recreate this from the template defaults instead?
-                    foreach (var val in file.ToObject<Dictionary<string, CombinedTemplateState>>().Values)
-                    {
-                        app._templateStore.AddTemplate(val);
-                    }
-                    continue;
-                }
-
-                // $$$ This should probably just be part of the data component template, no need to be a separate file
-                bool isDataComponentManifest = file._relativeName.EndsWith(".manifest.json", StringComparison.OrdinalIgnoreCase);
-                if (isDataComponentManifest)
-                {
-                    var json = file.ToObject< MinDataComponentManifest>();
-                    app._dataComponents.Add(json.TemplateGuid, json);
-                }
-            }
-
             foreach (var file in directory.EnumerateFiles(EditorStateDir, "*.json"))
             {
                 if (file.Kind == FileKind.Templates)
@@ -354,14 +333,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             // Write out the used templates from controls
             // These could be created as part of build tooling, and are from the control.json files for now
             dir.WriteAllText(EditorStateDir, "ControlTemplates.json", JsonSerializer.Serialize(app._templateStore.Contents, Utility._jsonOpts));
-
-            // Write out DataComponent pieces.
-            // These could all be infered from the .pa file, so write next to the src. 
-            foreach (MinDataComponentManifest dataComponent in app._dataComponents.Values)
-            {
-                string controlName = dataComponent.Name;
-                dir.WriteAllJson(CodeDir, controlName + ".manifest.json", dataComponent);
-            }
 
             // Expansions....    
             // These are ignorable, but provide extra decoding and visiblity into complex files. 


### PR DESCRIPTION
Moves .editorstate.json and ControlTemplates.json to /Src/EditorState, which can be deleted for simple apps (no components) and recreated on pack in a way that is still loadable in studio. 
![image](https://user-images.githubusercontent.com/69215460/101098870-880f8c00-3578-11eb-879b-e7455bb83d4a.png)

Also, eliminates the .manifest.json file for components and moves that data into the component template. 