### PR TITLE
Order children by ZIndex

### DIFF
--- a/src/PAModel/IR/IRStateHelpers.cs
+++ b/src/PAModel/IR/IRStateHelpers.cs
@@ -24,15 +24,15 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         private static void SplitIRAndState(ControlInfoJson.Item control, string topParentName, int index, EditorStateStore stateStore, TemplateStore templateStore, Entropy entropy, out BlockNode controlIR)
         {
             // Bottom up, recursively process children
-            var children = new List<BlockNode>();
+            var childrenWithZIndex = new List<KeyValuePair<BlockNode, double>>();
             var childIndex = 0;
             foreach (var child in control.Children)
             {
                 SplitIRAndState(child, topParentName, childIndex, stateStore, templateStore, entropy, out var childBlock);
-                children.Add(childBlock);
+                childrenWithZIndex.Add(new KeyValuePair<BlockNode, double>(childBlock, GetControlZIndex(child)));
                 ++childIndex;
             }
-
+            var children = childrenWithZIndex.OrderBy(kvp => kvp.Value).Select(kvp => kvp.Key);
             var isComponentDef = control.Template.IsComponentDefinition ?? false;
 
             var customPropsToHide = new HashSet<string>();
@@ -133,7 +133,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                         OptionalVariant = string.IsNullOrEmpty(control.VariantName) ? null : control.VariantName
                     }
                 },
-                Children = children,
+                Children = children.ToList(),
                 Properties = properties,
                 Functions = functions,
             };
@@ -177,6 +177,22 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             var prop = new PropertyNode() { Expression = new ExpressionNode() { Expression = script }, Identifier = rule.Property };
             var state = new PropertyState() { PropertyName = rule.Property, ExtensionData = rule.ExtensionData, NameMap = rule.NameMap, RuleProviderType = rule.RuleProviderType };
             return (prop, state);
+        }
+
+        internal static double GetControlZIndex(ControlInfoJson.Item control)
+        {
+            if (control.Rules == null)
+                return -1;
+
+            var zindexRule = control.Rules.FirstOrDefault(rule => rule.Property == "ZIndex");
+
+            if (zindexRule == default)
+                return -1;
+
+            if (!double.TryParse(zindexRule.InvariantScript, out var zindexResult) || double.IsNaN(zindexResult) || double.IsInfinity(zindexResult))
+                return -1;
+
+            return zindexResult;
         }
 
         internal static SourceFile CombineIRAndState(BlockNode blockNode, ErrorContainer errors, EditorStateStore stateStore, TemplateStore templateStore, UniqueIdRestorer uniqueIdRestorer)

--- a/src/PAModelTests/SrcBaseline/ComponentFunction_Test.pa.yaml
+++ b/src/PAModelTests/SrcBaseline/ComponentFunction_Test.pa.yaml
@@ -13,30 +13,6 @@ Component1 As CanvasComponent:
     Y: =0
     ZIndex: =1
 
-    Label3 As label:
-        Text: |-
-            ="Start:"
-        X: =40
-        Y: =72
-        ZIndex: =5
-
-    DatePicker1 As datepicker:
-        X: =171
-        Y: =72
-        ZIndex: =3
-
-    Label3_1 As label:
-        Text: |-
-            ="End: "
-        X: =40
-        Y: =159
-        ZIndex: =6
-
-    DatePicker2 As datepicker:
-        X: =171
-        Y: =159
-        ZIndex: =4
-
     Label2 As label:
         Text: |-
             ="The dates are valid: " & Component1.ValidateDates( DatePicker1.SelectedDate, DatePicker2.SelectedDate )
@@ -46,4 +22,28 @@ Component1 As CanvasComponent:
         Height: =46
         ZIndex: =2
         Size: =24
+
+    DatePicker1 As datepicker:
+        X: =171
+        Y: =72
+        ZIndex: =3
+
+    DatePicker2 As datepicker:
+        X: =171
+        Y: =159
+        ZIndex: =4
+
+    Label3 As label:
+        Text: |-
+            ="Start:"
+        X: =40
+        Y: =72
+        ZIndex: =5
+
+    Label3_1 As label:
+        Text: |-
+            ="End: "
+        X: =40
+        Y: =159
+        ZIndex: =6
 


### PR DESCRIPTION
fixes #117 

This updates our control ordering to (mostly) match what authors see in Studio's tree view