### PR TITLE
Fix capitalization of Pasopa in build script

### DIFF
--- a/targets/Program.cs
+++ b/targets/Program.cs
@@ -42,7 +42,7 @@ namespace targets
             string LogDir = Path.Combine(ObjDir, "logs");
             string TestLogDir = Path.Combine(ObjDir, "testLogs");
 
-            var solution = Path.Combine(RootDir, "src/PASoPa.sln");
+            var solution = Path.Combine(RootDir, "src/PASopa.sln");
             var project = Path.Combine(RootDir, "src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj");
 
             Target("squeaky-clean",


### PR DESCRIPTION
Partial fix for #124, we still have a number of test failures on linux that need to be addressed before we're truly cross-platform. 