### PR TITLE
Fix roundtrip failures for Legacy DataTable Control

### DIFF
--- a/src/PAModel/EditorState/CombinedTemplateState.cs
+++ b/src/PAModel/EditorState/CombinedTemplateState.cs
@@ -41,6 +41,9 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.EditorState
 
         public ComponentManifest ComponentManifest { get; set; } = null;
 
+        // Present on Legacy DataTable columns
+        public string CustomControlDefinitionJson { get; set; } = null;
+
         [JsonExtensionData]
         public Dictionary<string, object> ExtensionData { get; set; }
 
@@ -60,6 +63,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.EditorState
             ExtensionData = template.ExtensionData;
             ComponentType = template.ComponentType;
             FirstParty = template.FirstParty;
+            CustomControlDefinitionJson = template.CustomControlDefinitionJson;
         }
 
         public ControlInfoJson.Template ToControlInfoTemplate()
@@ -76,7 +80,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.EditorState
                 TemplateDisplayName = TemplateDisplayName,
                 ExtensionData = ExtensionData,
                 ComponentType = ComponentType,
-                FirstParty = FirstParty
+                FirstParty = FirstParty,
+                CustomControlDefinitionJson = CustomControlDefinitionJson
             };
         }
 

--- a/src/PAModel/Entropy.cs
+++ b/src/PAModel/Entropy.cs
@@ -55,6 +55,9 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         // Key is resource name
         public Dictionary<string, string> LocalResourceRootPaths { get; set; } = new Dictionary<string, string>(StringComparer.Ordinal);
 
+        // Key is control name, this should be unused if no datatables are present
+        public Dictionary<string, string> DataTableCustomControlTemplateJsons { get; set; }
+
         public PropertyEntropy VolatileProperties { get; set; }
 
         public int GetOrder(DataSourceEntry dataSource)
@@ -177,6 +180,27 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 return -1;
 
             return groupOrder.GetOrDefault(childName, -1);
+        }
+
+        public void AddDataTableControlJson(string controlName, string json)
+        {
+            if (DataTableCustomControlTemplateJsons == null)
+            {
+                DataTableCustomControlTemplateJsons = new Dictionary<string, string>();
+            }
+
+            DataTableCustomControlTemplateJsons.Add(controlName, json);
+        }
+
+        public bool TryGetDataTableControlJson(string controlName, out string json)
+        {
+            json = null;
+            if (DataTableCustomControlTemplateJsons == null)
+            {
+                return false;
+            }
+
+            return DataTableCustomControlTemplateJsons.TryGetValue(controlName, out json);
         }
     }
 }

--- a/src/PAModel/IR/IRStateHelpers.cs
+++ b/src/PAModel/IR/IRStateHelpers.cs
@@ -401,6 +401,11 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             return property;
         }
 
+
+        // These two functions (split and recombine CustomTemplates) are responsible for handling the legacy DataTable control's
+        // CustomControlDefinitionJson. This JSON contains a stamp of which version it was created in, but that is the only difference
+        // As such, they were safe to move to Entropy. If entropy is removed, the one in the TemplateStore works fine for all instances
+        // of the control.
         private static void SplitCustomTemplates(Entropy entropy, ControlInfoJson.Template controlTemplate, string controlName)
         {
             if (controlTemplate.Id != "Microsoft.PowerApps.CustomControlTemplate")

--- a/src/PAModel/IR/IRStateHelpers.cs
+++ b/src/PAModel/IR/IRStateHelpers.cs
@@ -402,13 +402,15 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         }
 
 
+
+        private static readonly string CustomControlTemplateId = "Microsoft.PowerApps.CustomControlTemplate";
         // These two functions (split and recombine CustomTemplates) are responsible for handling the legacy DataTable control's
         // CustomControlDefinitionJson. This JSON contains a stamp of which version it was created in, but that is the only difference
         // As such, they were safe to move to Entropy. If entropy is removed, the one in the TemplateStore works fine for all instances
         // of the control.
         private static void SplitCustomTemplates(Entropy entropy, ControlInfoJson.Template controlTemplate, string controlName)
         {
-            if (controlTemplate.Id != "Microsoft.PowerApps.CustomControlTemplate")
+            if (controlTemplate.Id != CustomControlTemplateId)
                 return;
 
             entropy.AddDataTableControlJson(controlName, controlTemplate.CustomControlDefinitionJson);
@@ -416,7 +418,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
         private static void RecombineCustomTemplates(Entropy entropy, ControlInfoJson.Template controlTemplate, string controlName)
         {
-            if (controlTemplate.Id != "Microsoft.PowerApps.CustomControlTemplate")
+            if (controlTemplate.Id != CustomControlTemplateId)
                 return;
 
             if (entropy.TryGetDataTableControlJson(controlName, out var customTemplateJson))

--- a/src/PAModel/IR/IRStateHelpers.cs
+++ b/src/PAModel/IR/IRStateHelpers.cs
@@ -154,6 +154,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 templateStore.AddTemplate(templateName, templateState);
             }
 
+            SplitCustomTemplates(entropy, control.Template, control.Name);
+
             entropy.ControlUniqueIds.Add(control.Name, int.Parse(control.ControlUniqueId));
             var controlState = new ControlState()
             {
@@ -180,14 +182,14 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             return (prop, state);
         }
 
-        internal static SourceFile CombineIRAndState(BlockNode blockNode, ErrorContainer errors, EditorStateStore stateStore, TemplateStore templateStore, UniqueIdRestorer uniqueIdRestorer)
+        internal static SourceFile CombineIRAndState(BlockNode blockNode, ErrorContainer errors, EditorStateStore stateStore, TemplateStore templateStore, UniqueIdRestorer uniqueIdRestorer, Entropy entropy)
         {
-            var topParentJson = CombineIRAndState(blockNode, errors, string.Empty, stateStore, templateStore, uniqueIdRestorer);
+            var topParentJson = CombineIRAndState(blockNode, errors, string.Empty, stateStore, templateStore, uniqueIdRestorer, entropy);
             return SourceFile.New(new ControlInfoJson() { TopParent = topParentJson.item });
         }
 
         // Returns pair of item and index (with respect to parent order)
-        private static (ControlInfoJson.Item item, int index) CombineIRAndState(BlockNode blockNode, ErrorContainer errors, string parent, EditorStateStore stateStore, TemplateStore templateStore, UniqueIdRestorer uniqueIdRestorer)
+        private static (ControlInfoJson.Item item, int index) CombineIRAndState(BlockNode blockNode, ErrorContainer errors, string parent, EditorStateStore stateStore, TemplateStore templateStore, UniqueIdRestorer uniqueIdRestorer, Entropy entropy)
         {
             var controlName = blockNode.Name.Identifier;
 
@@ -195,7 +197,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             var children = new List<(ControlInfoJson.Item item, int index)>();
             foreach (var childBlock in blockNode.Children)
             {
-                children.Add(CombineIRAndState(childBlock, errors, controlName, stateStore, templateStore, uniqueIdRestorer));
+                children.Add(CombineIRAndState(childBlock, errors, controlName, stateStore, templateStore, uniqueIdRestorer, entropy));
             }
 
             var orderedChildren = children.OrderBy(childPair => childPair.index).Select(pair => pair.item).ToArray();
@@ -213,6 +215,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             {
                 template = templateState.ToControlInfoTemplate();
             }
+
+            RecombineCustomTemplates(entropy, template, controlName);
 
             var uniqueId = uniqueIdRestorer.GetControlId(controlName);
             ControlInfoJson.Item resultControlInfo;
@@ -395,6 +399,25 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             }
 
             return property;
+        }
+
+        private static void SplitCustomTemplates(Entropy entropy, ControlInfoJson.Template controlTemplate, string controlName)
+        {
+            if (controlTemplate.Id != "Microsoft.PowerApps.CustomControlTemplate")
+                return;
+
+            entropy.AddDataTableControlJson(controlName, controlTemplate.CustomControlDefinitionJson);
+        }
+
+        private static void RecombineCustomTemplates(Entropy entropy, ControlInfoJson.Template controlTemplate, string controlName)
+        {
+            if (controlTemplate.Id != "Microsoft.PowerApps.CustomControlTemplate")
+                return;
+
+            if (entropy.TryGetDataTableControlJson(controlName, out var customTemplateJson))
+            {
+                controlTemplate.CustomControlDefinitionJson = customTemplateJson;
+            }
         }
     }
 }

--- a/src/PAModel/Schemas/adhoc/Control.cs
+++ b/src/PAModel/Schemas/adhoc/Control.cs
@@ -54,6 +54,9 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             public string TemplateDisplayName { get; set; } = null;
             public bool FirstParty { get; set; }
 
+            // Present on Legacy DataTable columns
+            public string CustomControlDefinitionJson { get; set; } = null;
+
             [JsonExtensionData]
             public Dictionary<string, object> ExtensionData { get; set; }
 
@@ -68,6 +71,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 LastModifiedTimestamp = other.LastModifiedTimestamp;
                 IsComponentDefinition = other.IsComponentDefinition;
                 ComponentDefinitionInfo = other.ComponentDefinitionInfo;
+                CustomControlDefinitionJson = other.CustomControlDefinitionJson;
                 CustomProperties = other.CustomProperties;
                 ExtensionData = other.ExtensionData;
             }

--- a/src/PAModel/Serializers/MsAppSerializer.cs
+++ b/src/PAModel/Serializers/MsAppSerializer.cs
@@ -500,7 +500,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                     (app._editorStateStore.TryGetControlState(source.Value.Name.Identifier, out var control) &&
                     (control.IsComponentDefinition ?? false)) ? -1 : 1))
             {
-                var sourceFile = IRStateHelpers.CombineIRAndState(controlData.Value, errors, app._editorStateStore, app._templateStore, idRestorer);
+                var sourceFile = IRStateHelpers.CombineIRAndState(controlData.Value, errors, app._editorStateStore, app._templateStore, idRestorer, app._entropy);
                 // Offset the publishOrderIndex based on Entropy.json
                 if (app._entropy.PublishOrderIndexOffsets.TryGetValue(sourceFile.ControlName, out var minIndex))
                 {


### PR DESCRIPTION
The CustomControlJson can vary slightly between columns for the legacy data table control. However, it's safe to just pick any individual json and use it for all the columns.

fixes #120 