### PR TITLE
Some datasources (like AIBuilder) don't have a wadl/swagger file.

### DIFF
--- a/src/PAModel/Serializers/SourceSerializer.cs
+++ b/src/PAModel/Serializers/SourceSerializer.cs
@@ -667,12 +667,11 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                     {
                         var foundXML = xmlDefs.TryGetValue(Path.GetFileNameWithoutExtension(file._relativeName), out string xmlDef);
                         var foundJson = swaggerDefs.TryGetValue(Path.GetFileNameWithoutExtension(file._relativeName), out string swaggerDef);
-                        if (!foundXML && !foundJson)
+
+                        if (foundXML || foundJson)
                         {
-                            errors.ValidationError($"No matching wadl or swagger def for {file._relativeName}");
-                            throw new DocumentException();
+                            ds.WadlMetadata = new WadlDefinition() { WadlXml = xmlDef, SwaggerJson = swaggerDef };
                         }
-                        ds.WadlMetadata = new WadlDefinition() { WadlXml = xmlDef, SwaggerJson = swaggerDef };
                     }
 
                     app.AddDataSourceForLoad(ds);


### PR DESCRIPTION
Fix #163.
