### PR TITLE
Add global.json to get dotnet tooling to lock into right version.

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "3.1.404",
+    "rollForward": "latestMinor"
+  }
+}


### PR DESCRIPTION
Else it will pick a random / latest version and can get build errors depending on what's installed.