### PR TITLE
Fix issue in GetRelativePath() when directory has a dot.

### DIFF
--- a/src/PAModel/Serializers/FileEntry.cs
+++ b/src/PAModel/Serializers/FileEntry.cs
@@ -72,7 +72,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
         public static FileEntry FromFile(string fullPath, string root)
         {
-            var relativePath = Utilities.GetRelativePath(fullPath, root);
+            var relativePath = Utilities.GetRelativePath(root, fullPath);
             var bytes = File.ReadAllBytes(fullPath);
             var entry = new FileEntry
             {

--- a/src/PAModel/Utility/DirectoryHelper.cs
+++ b/src/PAModel/Utility/DirectoryHelper.cs
@@ -162,7 +162,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             var fullPaths = Directory.EnumerateFiles(root, pattern, searchSubdirectories ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
 
             var entries = from fullPath in fullPaths
-                          let relativePath = Utilities.GetRelativePath(fullPath, root)
+                          let relativePath = Utilities.GetRelativePath(root, fullPath)
                           select new Entry(fullPath)
                           {
                               _relativeName = relativePath,

--- a/src/PAModel/Utility/Utilities.cs
+++ b/src/PAModel/Utility/Utilities.cs
@@ -148,16 +148,19 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         // returns "bar\hi.txt"
 
         // Net Core 2.1 provides a Path.GetRelativePath api
-        // but since we target netstandard, we can convert to URIs and make the relative path from that
+        // but since we target netstandard 2.0, we can convert to URIs and make the relative path from that
         // see https://stackoverflow.com/questions/275689/how-to-get-relative-path-from-absolute-path
-        public static string GetRelativePath(string full, string basePath)
+        // For reference, see Core's impl at: https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs#L861
+        public static string GetRelativePath(string fullPathFile, string basePathDirectory)
         {
-            Uri fromUri = new Uri(AppendDirectorySeparatorChar(basePath));
-            Uri toUri = new Uri(AppendDirectorySeparatorChar(full));
+            // First arg is always a path name, 2nd arg is always a directory.
+            // directory is always a prefix. 
+            Uri fromUri = new Uri(AppendDirectorySeparatorChar(basePathDirectory));
+            Uri toUri = new Uri(fullPathFile);
 
             // path can't be made relative.
             if (fromUri.Scheme != toUri.Scheme)
-                return full;
+                return fullPathFile;
 
             Uri relativeUri = fromUri.MakeRelativeUri(toUri);
             string relativePath = Uri.UnescapeDataString(relativeUri.ToString());
@@ -170,16 +173,15 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             return relativePath;
         }
 
-        private static string AppendDirectorySeparatorChar(string path)
+        private static string AppendDirectorySeparatorChar(string fullDirectory)
         {
-            // Append a slash only if the path is a directory and does not have a slash.
-            if (!Path.HasExtension(path) &&
-                !path.EndsWith(Path.DirectorySeparatorChar.ToString()))
+            // Append a slash only if the path does not already have a slash.
+            if (!fullDirectory.EndsWith(Path.DirectorySeparatorChar.ToString()))
             {
-                return path + Path.DirectorySeparatorChar;
+                return fullDirectory + Path.DirectorySeparatorChar;
             }
 
-            return path;
+            return fullDirectory;
         }
 
         public static void EnsureNoExtraData(Dictionary<string, JsonElement> extra)

--- a/src/PAModel/Utility/Utilities.cs
+++ b/src/PAModel/Utility/Utilities.cs
@@ -143,19 +143,28 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             }
         }
 
-        // basePath:     C:\foo
-        // full: c:\foo\bar\hi.txt
-        // returns "bar\hi.txt"
-
-        // Net Core 2.1 provides a Path.GetRelativePath api
-        // but since we target netstandard 2.0, we can convert to URIs and make the relative path from that
-        // see https://stackoverflow.com/questions/275689/how-to-get-relative-path-from-absolute-path
-        // For reference, see Core's impl at: https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs#L861
-        public static string GetRelativePath(string fullPathFile, string basePathDirectory)
+        /// <summary>
+        /// Create a relative path from one path to another. Paths will be resolved before calculating the difference.
+        /// Default path comparison for the active platform will be used (OrdinalIgnoreCase for Windows or Mac, Ordinal for Unix).
+        ///   basePath:     C:\foo
+        ///   full: c:\foo\bar\hi.txt
+        ///   returns "bar\hi.txt"
+        /// </summary>
+        /// <param name="relativeTo">The source path the output should be relative to. This path is always considered to be a directory.</param>
+        /// <param name="fullPathFile">The destination path. This is always a full path to a file.</param>
+        /// <returns>The relative path or <paramref name="path"/> if the paths don't share the same root.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="relativeTo"/> or <paramref name="path"/> is <c>null</c> or an empty string.</exception>
+        /// <remarks>
+        /// Want to use Path.GetRelativePath() from Net 2.1. But since we target netstandard 2.0, we need to shim it.
+        /// Convert to URIs and make the relative path. 
+        /// see https://stackoverflow.com/questions/275689/how-to-get-relative-path-from-absolute-path
+        /// For reference, see Core's impl at: https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs#L861
+        /// </remarks>
+        public static string GetRelativePath(string relativeTo, string fullPathFile)
         {
             // First arg is always a path name, 2nd arg is always a directory.
             // directory is always a prefix. 
-            Uri fromUri = new Uri(AppendDirectorySeparatorChar(basePathDirectory));
+            Uri fromUri = new Uri(AppendDirectorySeparatorChar(relativeTo));
             Uri toUri = new Uri(fullPathFile);
 
             // path can't be made relative.

--- a/src/PAModelTests/UtilityTests.cs
+++ b/src/PAModelTests/UtilityTests.cs
@@ -54,7 +54,7 @@ namespace PAModelTests
                 basePath = basePath.Replace('\\', '/');
                 expectedRelativePath = expectedRelativePath.Replace('\\', '/');
             }
-            Assert.AreEqual(expectedRelativePath, Utilities.GetRelativePath(fullPath, basePath));
+            Assert.AreEqual(expectedRelativePath, Utilities.GetRelativePath(basePath, fullPath));
         }
 
 

--- a/src/PAModelTests/UtilityTests.cs
+++ b/src/PAModelTests/UtilityTests.cs
@@ -36,16 +36,15 @@ namespace PAModelTests
         }
 
         [DataTestMethod]
-        // [DataRow("C:\\Foo\\Bar\\Baz", "C:\\Foo", "Bar\\Baz\\")]
-        // [DataRow("C:\\Foo\\Bar\\Baz", "C:\\Foo\\", "Bar\\Baz\\")]
-        // [DataRow("C:\\Foo\\Bar\\Baz\\", "C:\\Foo\\", "Bar\\Baz\\")]
-        // [DataRow("C:\\Foo\\Bar.msapp", "C:\\Foo", "Bar.msapp")]
-        // [DataRow("C:\\Foo\\Bar.msapp", "C:\\Foo\\", "Bar.msapp")]
-        // [DataRow("C:\\Foo\\Bar.msapp", "C:\\", "Foo\\Bar.msapp")]
+        [DataRow("C:\\Foo\\Bar\\file", "C:\\Foo", "Bar\\file")]
+        [DataRow("C:\\Foo\\Bar\\file", "C:\\Foo\\", "Bar\\file")]
+        [DataRow("C:\\Foo\\Bar.msapp", "C:\\Foo", "Bar.msapp")]
+        [DataRow("C:\\Foo\\Bar.msapp", "C:\\Foo\\", "Bar.msapp")]
+        [DataRow("C:\\Foo\\Bar.msapp", "C:\\", "Foo\\Bar.msapp")]
         [DataRow(@"C:\DataSources\JourneyPlanner|Sendforapproval.json", "C:\\", @"DataSources\JourneyPlanner|Sendforapproval.json")]
         [DataRow(@"C:\DataSources\JourneyPlanner%7cSendforapproval.json", "C:\\", @"DataSources\JourneyPlanner%7cSendforapproval.json")]
-        // [DataRow(@"d:\app\Src\EditorState\Screen%252.editorstate.json",
-        //     @"d:\app", @"Src\EditorState\Screen%252.editorstate.json" )]
+        [DataRow(@"d:\app\Src\EditorState\Screen%252.editorstate.json", @"d:\app", @"Src\EditorState\Screen%252.editorstate.json" )]
+        [DataRow(@"C:\Temp\MySolution\MySolution.Project\DataSources\JourneyPlanner%7cSendforapproval.json", @"C:\Temp\MySolution\MySolution.Project", @"DataSources\JourneyPlanner%7cSendforapproval.json")]
         public void TestRelativePath(string fullPath, string basePath, string expectedRelativePath)
         {
             // Test non-windows paths if on other platforms


### PR DESCRIPTION
Thanks to @StevenRasmussen  for reporting and submitting ideas at, https://github.com/microsoft/PowerApps-Language-Tooling/issues/202, 

- also reenables some tests that were accidentally removed 
