### PR TITLE
Handling for empty LocalDatabaseReferences which has valid CDS datasource

### DIFF
--- a/src/PAModel/Serializers/MsAppSerializer.cs
+++ b/src/PAModel/Serializers/MsAppSerializer.cs
@@ -253,14 +253,14 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 // Normalize logo filename. 
                 app.TranformLogoOnLoad();
 
-                if (app._properties.LibraryDependencies != null)
+                if (!string.IsNullOrEmpty(app._properties.LibraryDependencies))
                 {
                     var refs = Utilities.JsonParse<ComponentDependencyInfo[]>(app._properties.LibraryDependencies);
                     app._libraryReferences = refs;
                     app._properties.LibraryDependencies = null;
                 }
 
-                if (app._properties.LocalConnectionReferences != null)
+                if (!string.IsNullOrEmpty(app._properties.LocalConnectionReferences))
                 {
                     var cxs = Utilities.JsonParse<IDictionary<String, ConnectionJson>>(app._properties.LocalConnectionReferences);
                     app._connections = cxs;

--- a/src/PAModel/Serializers/SourceSerializer.cs
+++ b/src/PAModel/Serializers/SourceSerializer.cs
@@ -583,7 +583,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                     TrimViewNames(dataSourceStateToWrite, dataSourceDef.DatasetName);
                 }
 
-                if (dataSourceDef?.DatasetName != null && app._dataSourceReferences.TryGetValue(dataSourceDef.DatasetName, out var referenceJson))
+                if (dataSourceDef?.DatasetName != null && app._dataSourceReferences != null && app._dataSourceReferences.TryGetValue(dataSourceDef.DatasetName, out var referenceJson))
                 {
                     // copy over the localconnectionreference
                     if (referenceJson.dataSources.TryGetValue(dataSourceDef.EntityName, out var dsRef))
@@ -621,7 +621,10 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                         ExtensionData = tableDef.ExtensionData,
                         instanceUrl = tableDef.InstanceUrl
                     };
-                    app._dataSourceReferences.Add(tableDef.DatasetName, localDatabaseReferenceJson);
+                    if (!app._entropy.LocalDatabaseReferencesAsEmpty)
+                    {
+                        app._dataSourceReferences.Add(tableDef.DatasetName, localDatabaseReferenceJson);
+                    }
                 }
                 if (localDatabaseReferenceJson.instanceUrl != tableDef.InstanceUrl)
                 {
@@ -631,7 +634,10 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                     throw new DocumentException();
                 }
 
-                localDatabaseReferenceJson.dataSources.Add(tableDef.EntityName, tableDef.LocalReferenceDSJson);
+                if (tableDef.LocalReferenceDSJson != null)
+                {
+                    localDatabaseReferenceJson.dataSources.Add(tableDef.EntityName, tableDef.LocalReferenceDSJson);
+                }
             }
 
             // key is filename, value is stringified xml

--- a/src/PAModel/SourceTransforms/ComponentDefinitionTransform.cs
+++ b/src/PAModel/SourceTransforms/ComponentDefinitionTransform.cs
@@ -48,6 +48,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
                     kindName = ComponentType.CanvasComponent.ToString();
                 else if (componentTemplate.Id == ControlInfoJson.Template.DataComponentId)
                     kindName = ComponentType.DataComponent.ToString();
+                else if (componentTemplate.Id == ControlInfoJson.Template.CommandComponentId)
+                    kindName = ComponentType.CanvasComponent.ToString();
                 else
                     return; // We couldn't find a component type. Just keep using the guid.
             }


### PR DESCRIPTION
Made the changes to handle for empty LocalDatabaseReferences property in proerties.json when the app has default cds as data source. This is happening for command components.

Also in certain cases the data source in table definition is null which causes failure during round trip, added fix for that as well.