### PR TITLE
Ensure group controls with missing editor state load correctly in Studio

### DIFF
--- a/src/PAModel/IR/IRStateHelpers.cs
+++ b/src/PAModel/IR/IRStateHelpers.cs
@@ -305,7 +305,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
                 // Preserve ordering from serialized IR
                 // Required for roundtrip checks
-                properties = properties.OrderBy(prop => state.Properties.Select(propState => propState.PropertyName).ToList().IndexOf(prop.Property)).ToList();
+                properties = properties.OrderBy(prop => state.Properties?.Select(propState => propState.PropertyName).ToList().IndexOf(prop.Property) ?? -1).ToList();
                 resultControlInfo = new ControlInfoJson.Item()
                 {
                     Parent = parent,
@@ -455,7 +455,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             property.InvariantScript = expression;
 
             PropertyState propState = null;
-            if (state.Properties.ToDictionary(prop => prop.PropertyName).TryGetValue(propName, out propState))
+            if (state.Properties != null && state.Properties.ToDictionary(prop => prop.PropertyName).TryGetValue(propName, out propState))
             {
                 property.ExtensionData = propState.ExtensionData;
                 property.NameMap = propState.NameMap;

--- a/src/PAModel/SourceTransforms/DefaultValuesTransform.cs
+++ b/src/PAModel/SourceTransforms/DefaultValuesTransform.cs
@@ -58,7 +58,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
             var styleName = $"default{templateName.FirstCharToUpper()}Style";
 
             HashSet<string> propNames = null;
-            if (_controlStore.TryGetControlState(controlName, out var controlState))
+            if (_controlStore.TryGetControlState(controlName, out var controlState) && controlState.Properties != null)
             {
                 styleName = controlState.StyleName;
                 propNames = new HashSet<string>(controlState.Properties.Select(state => state.PropertyName)

--- a/src/PAModel/SourceTransforms/GroupControlTransform.cs
+++ b/src/PAModel/SourceTransforms/GroupControlTransform.cs
@@ -82,11 +82,13 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
                     // There may not be editorstate present for this. Create a fake state to use
                     groupControlState = new ControlState()
                     {
+                        Name = groupControlName,
                         StyleName = "",
-                        ParentIndex = -1,
+                        ParentIndex = int.MaxValue, // Group controls must be ordered after their children
                         IsGroupControl = true,
                         ExtensionData = ControlInfoJson.Item.CreateDefaultExtensionData()
                     };
+                    _editorStateStore.TryAddControl(groupControlState);
                 }
 
                 var groupedControlNames = groupControl.Children

--- a/src/PAModelTests/GroupControlRecreationTest.cs
+++ b/src/PAModelTests/GroupControlRecreationTest.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.PowerPlatform.Formulas.Tools;
+using Microsoft.PowerPlatform.Formulas.Tools.IR;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace PAModelTests
+{
+    [TestClass]
+    public class GroupControlRecreationTest
+    {
+        // Test that group controls are moved to the end of the list when the editorstate is removed. 
+        [TestMethod]
+        public void TestGroupControlRecreation()
+        {
+            // Pull both the msapp and the baseline from our embedded resources. 
+            var root = Path.Combine(Environment.CurrentDirectory, "Apps", "GroupControlTest.msapp");
+            Assert.IsTrue(File.Exists(root));
+
+            (var msapp, var errors) = CanvasDocument.LoadFromMsapp(root);
+            errors.ThrowOnErrors();
+
+            msapp._editorStateStore.Remove("Group1");
+
+            msapp.ApplyBeforeMsAppWriteTransforms(errors);
+            errors.ThrowOnErrors();
+
+            Assert.IsTrue(msapp._screens.TryGetValue("Screen1", out var screen));
+
+            var sourceFile = IRStateHelpers.CombineIRAndState(screen, errors, msapp._editorStateStore, msapp._templateStore, new UniqueIdRestorer(msapp._entropy), msapp._entropy);
+
+            Assert.AreEqual("Screen1", sourceFile.ControlName);
+
+            // Check that the group control was still moved to the end of the children list
+            Assert.AreEqual("Group1", sourceFile.Value.TopParent.Children.Last().Name);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #209 
In the control .json file, group controls must be ordered after the controls they are grouping of, to ensure that they are reparented correctly when loading. 