### PR TITLE
#211: adding new error type for unsupported scenarios.

### DIFF
--- a/src/PAModel/IR/IRStateHelpers.cs
+++ b/src/PAModel/IR/IRStateHelpers.cs
@@ -465,7 +465,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             {
                 if (state.IsComponentDefinition ?? false)
                 {
-                    errors.UnsupportedError("This tool currently does not support adding new custom properties to components. Please use Power Apps Studio to edit component definitions");
+                    errors.UnsupportedOperationError("This tool currently does not support adding new custom properties to components. Please use Power Apps Studio to edit component definitions");
                     throw new DocumentException();
                 }
 

--- a/src/PAModel/PAConvert/ErrorCode.cs
+++ b/src/PAModel/PAConvert/ErrorCode.cs
@@ -58,6 +58,10 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         // Catch-all.  Should review and make these more specific. 
         Generic = 3999,
 
+        // Some of the cases which the tool doesn't support, see below example:
+        // Connection Accounts is using the old CDS connector which is incompatable with this tool
+        UnsupportedError = 4001
+
     }
 
     internal static class ErrorCodeExtensions
@@ -102,7 +106,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             errors.AddError(ErrorCode.InternalError, default(SourceLocation), $"Internal error. {e.Message}");
         }
 
-        public static void UnsupportedError(this ErrorContainer errors, string message)
+        public static void UnsupportedOperationError(this ErrorContainer errors, string message)
         {
             errors.AddError(ErrorCode.UnsupportedUseStudio, default(SourceLocation), $"Unsupported operation error. {message}");
         }
@@ -137,5 +141,9 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             errors.AddError(ErrorCode.CantReadMsApp, default(SourceLocation), $"MsApp is corrupted: {message}");
         }
 
+        public static void UnsupportedError(this ErrorContainer errors, string message)
+        {
+            errors.AddError(ErrorCode.UnsupportedError, default(SourceLocation), $"Not Supported: {message}");
+        }
     }
 }

--- a/src/PAModel/Serializers/SourceSerializer.cs
+++ b/src/PAModel/Serializers/SourceSerializer.cs
@@ -547,7 +547,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                         if (ds.ApiId == "/providers/microsoft.powerapps/apis/shared_commondataservice")
                         {
                             // This is the old CDS connector, we can't support it since it's optionset format is incompatable with the newer one
-                            errors.UnsupportedError($"Connection {ds.Name} is using the old CDS connector which is incompatable with this tool");
+                            errors.UnsupportedError($"Connection {ds.Name} is using the old CDS connector which is incompatible with this tool");
                             throw new DocumentException();
                         }
                         dataSourceDef = new DataSourceDefinition();

--- a/src/PAModel/Serializers/SourceSerializer.cs
+++ b/src/PAModel/Serializers/SourceSerializer.cs
@@ -547,7 +547,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                         if (ds.ApiId == "/providers/microsoft.powerapps/apis/shared_commondataservice")
                         {
                             // This is the old CDS connector, we can't support it since it's optionset format is incompatable with the newer one
-                            errors.ValidationError($"Connection {ds.Name} is using the old CDS connector which is incompatable with this tool");
+                            errors.UnsupportedError($"Connection {ds.Name} is using the old CDS connector which is incompatable with this tool");
                             throw new DocumentException();
                         }
                         dataSourceDef = new DataSourceDefinition();


### PR DESCRIPTION
Adding a new error code for scenarios which are not supported by the tool.
Eg: "Connection Accounts is using the old CDS connector which is incompatible with this tool"