### PR TITLE
Changes to ensure the table definitions are added last if the entropy information is missing.

### DIFF
--- a/src/PAModel/CanvasDocument.cs
+++ b/src/PAModel/CanvasDocument.cs
@@ -319,7 +319,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
             StabilizeAssetFilePaths(errors);
 
-            // Don't persist entries for LocalFile resources in Resources.json
+            // Persist the original order of resource entries in Resources.json in the entropy.
             this.PersisOrderingOfResourcesJsonEntries();
         }
 

--- a/src/PAModel/CanvasDocument.cs
+++ b/src/PAModel/CanvasDocument.cs
@@ -320,7 +320,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             StabilizeAssetFilePaths(errors);
 
             // Persist the original order of resource entries in Resources.json in the entropy.
-            this.PersisOrderingOfResourcesJsonEntries();
+            this.PersistOrderingOfResourcesJsonEntries();
         }
 
         internal void ApplyBeforeMsAppWriteTransforms(ErrorContainer errors)

--- a/src/PAModel/Entropy.cs
+++ b/src/PAModel/Entropy.cs
@@ -69,7 +69,9 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
         public int GetOrder(DataSourceEntry dataSource)
         {
-            return this.OrderDataSource.GetOrDefault<string, int>(dataSource.GetUniqueName(), -1);
+            // To ensure that that TableDefinitions are put at the end in DataSources.json when the order information is not available.
+            var defaultValue = dataSource.TableDefinition != null ? int.MaxValue : -1;
+            return this.OrderDataSource.GetOrDefault<string, int>(dataSource.GetUniqueName(), defaultValue);
         }
         public void Add(DataSourceEntry entry, int? order)
         {

--- a/src/PAModel/Serializers/MsAppSerializer.cs
+++ b/src/PAModel/Serializers/MsAppSerializer.cs
@@ -538,8 +538,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 yield return ToFile(FileKind.PublishInfo, publishInfo);
 
             // "DataComponent" data sources are not part of DataSource.json, and instead in their own file
-            // In case the the entropy is missing then make sure that tableDefinitions are being added towards the end in DataSources.json file
-            // This is to respect the serialization order of the server.
             var dataSources = new DataSourcesJson
             {
                 DataSources = app.GetDataSources()
@@ -548,7 +546,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                     .OrderBy(x => app._entropy.GetOrder(x))
                     .ToArray()
             };
-
             yield return ToFile(FileKind.DataSources, dataSources);
 
             var sourceFiles = new List<SourceFile>();

--- a/src/PAModel/Serializers/MsAppSerializer.cs
+++ b/src/PAModel/Serializers/MsAppSerializer.cs
@@ -41,7 +41,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
             ComponentsMetadataJson componentsMetadata = null;
             DataComponentTemplatesJson dctemplate = null;
-            DataComponentSourcesJson dcsources  = null;
+            DataComponentSourcesJson dcsources = null;
 
             ChecksumMaker checksumMaker = new ChecksumMaker();
             // key = screen, value = index
@@ -50,7 +50,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             ZipArchive zipOpen;
             try
             {
-                zipOpen = new ZipArchive(streamToMsapp, ZipArchiveMode.Read);                
+                zipOpen = new ZipArchive(streamToMsapp, ZipArchiveMode.Read);
             }
             catch (Exception e)
             {
@@ -195,9 +195,9 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                     }
                 } // foreach zip entry
 
-                foreach(var template in app._templates.UsedTemplates)
+                foreach (var template in app._templates.UsedTemplates)
                 {
-                    if(app._templateStore.TryGetTemplate(template.Name, out var templateState))
+                    if (app._templateStore.TryGetTemplate(template.Name, out var templateState))
                     {
                         templateState.IsWidgetTemplate = true;
                     }
@@ -385,7 +385,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             if (!fullpathToMsApp.EndsWith(".msapp", StringComparison.OrdinalIgnoreCase) &&
                 fullpathToMsApp.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
             {
-                
+
                 throw new InvalidOperationException("Only works for .msapp files");
             }
 
@@ -461,7 +461,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
                 errors.ChecksumMismatch("Checksum indicates that sources have been edited since they were unpacked. If this was intentional, ignore this warning.");
             }
-            
+
             var checksumJson = new ChecksumJson
             {
                 ClientStampedChecksum = hash.wholeChecksum,
@@ -492,14 +492,14 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             var header = app._header.JsonClone();
             header.LastSavedDateTimeUTC = app._entropy.GetHeaderLastSaved();
             yield return ToFile(FileKind.Header, header);
-            
+
             var props = app._properties.JsonClone();
             if (app._connections != null)
             {
                 var json = Utilities.JsonSerialize(app._connections);
                 props.LocalConnectionReferences = json;
             }
-            if(app._appInsights != null)
+            if (app._appInsights != null)
             {
                 props.InstrumentationKey = app._appInsights.InstrumentationKey;
             }
@@ -513,13 +513,14 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                     if (app._entropy.LocalDatabaseReferencesAsEmpty)
                     {
                         json = "";
-                    } else
+                    }
+                    else
                     {
                         json = "{}";
                     }
                 }
 
-                props.LocalDatabaseReferences = json;                
+                props.LocalDatabaseReferences = json;
             }
 
             if (app._libraryReferences != null)
@@ -543,15 +544,10 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             {
                 DataSources = app.GetDataSources()
                     .SelectMany(x => x.Value)
-                    .Where(x => !x.IsDataComponent && x.TableDefinition == null)
+                    .Where(x => !x.IsDataComponent)
                     .OrderBy(x => app._entropy.GetOrder(x))
                     .ToArray()
             };
-            dataSources.DataSources = dataSources.DataSources.Concat(app.GetDataSources()
-                    .SelectMany(x => x.Value)
-                    .Where(x => x.TableDefinition != null))
-                    .OrderBy(x => app._entropy.GetOrder(x))
-                    .ToArray();
 
             yield return ToFile(FileKind.DataSources, dataSources);
 
@@ -797,5 +793,4 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             return new FileEntry { Name = filename, RawBytes = bytes };
         }
     }
-
 }

--- a/src/PAModel/Serializers/TransformResourceJson.cs
+++ b/src/PAModel/Serializers/TransformResourceJson.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         /// Persists the original order of resources in Resources.json in Entropy.
         /// </summary>
         /// <param name="app">The app.</param>
-        public static void PersisOrderingOfResourcesJsonEntries(this CanvasDocument app)
+        public static void PersistOrderingOfResourcesJsonEntries(this CanvasDocument app)
         {
             for (var i = 0; i < app._resourcesJson.Resources.Length; i++)
             {

--- a/src/PAModelTests/DataSourceTests.cs
+++ b/src/PAModelTests/DataSourceTests.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.PowerPlatform.Formulas.Tools;
+using Microsoft.PowerPlatform.Formulas.Tools.Utility;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+
+namespace PAModelTests
+{
+    // DataSources Tests
+    [TestClass]
+    public class DataSourceTests
+    {
+        // Validates that the TableDefinitions are being added at the end of the DataSources.json when the entropy file is deleted.
+        [DataTestMethod]
+        [DataRow("GalleryTestApp.msapp")]
+        [DataRow("AccountPlanReviewerMaster.msapp")]
+        public void TestTableDefinitionsAreLastEntriesWhenEntropyDeleted(string appName)
+        {
+            var root = Path.Combine(Environment.CurrentDirectory, "Apps", appName);
+            Assert.IsTrue(File.Exists(root));
+
+            (var msapp, var errors) = CanvasDocument.LoadFromMsapp(root);
+            errors.ThrowOnErrors();
+
+            using (var tempDir = new TempDir())
+            {
+                string outSrcDir = tempDir.Dir;
+
+                // Save to sources
+                msapp.SaveToSources(outSrcDir);
+
+                // Delete Entropy directory
+                var entropyPath = Path.Combine(outSrcDir, "Entropy");
+                if(Directory.Exists(entropyPath))
+                {
+                    Directory.Delete(entropyPath, true);
+                }
+
+                // Load app from the sources after deleting the entropy
+                var app = SourceSerializer.LoadFromSource(outSrcDir, new ErrorContainer());
+
+                using (var tempFile = new TempFile())
+                {
+                    // Repack the app
+                    MsAppSerializer.SaveAsMsApp(app, tempFile.FullPath, new ErrorContainer());
+
+                    using (var stream = new FileStream(tempFile.FullPath, FileMode.Open))
+                    {
+                        // Read the msapp file
+                        ZipArchive zipOpen = new ZipArchive(stream, ZipArchiveMode.Read);
+
+                        foreach (var entry in zipOpen.Entries)
+                        {
+                            var kind = FileEntry.TriageKind(FilePath.FromMsAppPath(entry.FullName));
+
+                            switch (kind)
+                            {
+                                // Validate that the last entry in the DataSources.json is TableDefinition entry.
+                                case FileKind.DataSources:
+                                    {
+                                        var dataSourcesFromMsapp = ToObject<DataSourcesJson>(entry);
+                                        var last = dataSourcesFromMsapp.DataSources.LastOrDefault();
+                                        Assert.AreEqual(last.TableDefinition != null, true);
+                                        return;
+                                    }
+                                default:
+                                    break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private static T ToObject<T>(ZipArchiveEntry entry)
+        {
+            var je = entry.ToJson();
+            return je.ToObject<T>();
+        }
+    }
+}


### PR DESCRIPTION
Table Definitions need to be added after the ViewInfo elements to ensure serialization order of the server is respected.