### PR TITLE
#187 Truncating the file names if length exceeds MAX_PATH

### DIFF
--- a/src/PAModel/Serializers/SourceSerializer.cs
+++ b/src/PAModel/Serializers/SourceSerializer.cs
@@ -42,7 +42,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         // 19 - Switch extension to .fx.yaml  
         // 20 - Only load themes that match the specified theme name
         // 21 - Resourcesjson is sharded into individual json files for non-local resources.
-        public static Version CurrentSourceVersion = new Version(0, 21);
+        // 22 - Unicodes are allowed to be part of filename and the filename is limited to 60 characters length, if it's more then it gets truncated.
+        public static Version CurrentSourceVersion = new Version(0, 22);
 
         // Layout is:
         //  src\

--- a/src/PAModel/Utility/DirectoryHelper.cs
+++ b/src/PAModel/Utility/DirectoryHelper.cs
@@ -69,7 +69,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
         public void WriteAllText(string subdir, FilePath filename, string text)
         {
-            string path = FilePath.ToValidPath(Path.Combine(_directory, subdir, filename.ToPlatformPath()));
+            string path = Path.Combine(_directory, subdir, filename.ToPlatformPath());
             EnsureFileDirExists(path);
             File.WriteAllText(path, text);
         }

--- a/src/PAModel/Utility/DirectoryHelper.cs
+++ b/src/PAModel/Utility/DirectoryHelper.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.AppMagic.Authoring.Persistence;
-using System;
 using System.IO;
 using System.Text.Json;
 using System.Linq;

--- a/src/PAModel/Utility/DirectoryHelper.cs
+++ b/src/PAModel/Utility/DirectoryHelper.cs
@@ -35,6 +35,12 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                     continue;
                 Directory.Delete(dir, recursive: true);
             }
+            foreach (var file in Directory.EnumerateFiles(_directory))
+            {
+                if (file.StartsWith(".git"))
+                    continue;
+                File.Delete(file);
+            }
         }
 
         public void WriteAllJson<T>(string subdir, FileKind kind, T obj)
@@ -70,6 +76,13 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         public void WriteAllText(string subdir, FilePath filename, string text)
         {
             string path = Path.Combine(_directory, subdir, filename.ToPlatformPath());
+
+            // Check for collision so that we don't overwrite an existing file.
+            if (File.Exists(path))
+            {
+                path = FilePath.ToFilePath(path).HandleFileNameCollisions(path);
+            }
+
             EnsureFileDirExists(path);
             File.WriteAllText(path, text);
         }

--- a/src/PAModel/Utility/DirectoryHelper.cs
+++ b/src/PAModel/Utility/DirectoryHelper.cs
@@ -71,7 +71,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
         public void WriteAllText(string subdir, FilePath filename, string text)
         {
-            string path = Path.Combine(_directory, subdir, filename.ToPlatformPath());
+            string path = FilePath.ToValidPath(Path.Combine(_directory, subdir, filename.ToPlatformPath()));
             EnsureFileDirExists(path);
             File.WriteAllText(path, text);
         }

--- a/src/PAModel/Utility/FilePath.cs
+++ b/src/PAModel/Utility/FilePath.cs
@@ -35,8 +35,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Utility
         public string ToPlatformPath()
         {
             var originalFileName = this.GetFileName();
-            var newFileName = GetTruncatedFileNameIfTooLong(this.GetFileName());
-            var remainingPath =  Path.Combine(_pathSegments.Where(x => x != originalFileName).Select(Utilities.EscapeFilename).ToArray());
+            var newFileName = GetTruncatedFileNameIfTooLong(originalFileName);
+            var remainingPath = Path.Combine(_pathSegments.Where(x => x != originalFileName).Select(Utilities.EscapeFilename).ToArray());
             return Path.Combine(remainingPath, newFileName);
         }
 
@@ -54,6 +54,14 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Utility
                 return new FilePath();
             var segments = path.Split('\\');
             return new FilePath(segments);
+        }
+
+        public static FilePath ToFilePath(string path)
+        {
+            if (path == null)
+                return new FilePath();
+            var segments = path.Split(Path.DirectorySeparatorChar).Select(x => x);
+            return new FilePath(segments.ToArray());
         }
 
         public static FilePath RootedAt(string root, FilePath remainder)
@@ -123,24 +131,40 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Utility
         }
 
         /// <summary>
-        /// If the file name length is longer than 60, it is truncated and appeded with a hash (to avoid collisions).
-        /// Checks the length of the escaped file name, since its possible that the length is under 60 before excaping but goes beyond 60 later.
-        /// We do module by 1000 of the hash to limit it to 3 characters.
+        /// If there is a collision in the filename then it generates a new name for the file by appending '_1', '_2' ... to the filename.S
+        /// </summary>
+        /// <param name="path">The string representation of the path including filename.</param>
+        /// <returns>Returns the updated path which has new filename.</returns>
+        public string HandleFileNameCollisions(string path)
+        {
+            var suffixCounter = 0;
+            var fileName = this.GetFileName();
+            var extension = GetCustomExtension(fileName);
+            var fileNameWithoutExtension = fileName.Substring(0, fileName.Length - extension.Length);
+            var pathWithoutFileName = path.Substring(0, path.Length - fileName.Length);
+            while (File.Exists(path))
+            {
+                var filename = fileNameWithoutExtension + '_' + ++suffixCounter + extension;
+                path = pathWithoutFileName + filename;
+            }
+            return path;
+        }
+
+        /// <summary>
+        /// If the file name length is longer than 60, it is truncated and appended with a hash (to avoid collisions).
+        /// Checks the length of the escaped file name, since its possible that the length is under 60 before escaping but goes beyond 60 later.
+        /// We do modulo by 1000 of the hash to limit it to 3 characters.
         /// </summary>
         /// <returns></returns>
         private string GetTruncatedFileNameIfTooLong(string fileName)
         {
             var newFileName = Utilities.EscapeFilename(fileName);
-            if (newFileName.Length > 60)
+            if (newFileName.Length > MaxFileNameLength)
             {
-                var extension = newFileName.EndsWith(yamlExtension)
-                    ? yamlExtension
-                    : newFileName.EndsWith(editorStateExtension)
-                    ? editorStateExtension
-                    : Path.GetExtension(newFileName);
+                var extension = GetCustomExtension(newFileName);
 
                 // limit the hash to 3 characters by doing a module by 1000
-                var hash = (GetHash(newFileName) % 1000).ToString("x3");
+                var hash = (GetHash(newFileName.Substring(0, newFileName.Length - extension.Length)) % 1000).ToString("x3");
                 newFileName = newFileName.Substring(0, MaxFileNameLength - extension.Length - hash.Length) + hash + extension;
             }
             return newFileName;
@@ -154,12 +178,22 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Utility
         private ulong GetHash(string str)
         {
             ulong hash = 5381;
-            foreach(char c in str)
+            foreach (char c in str)
             {
                 hash = ((hash << 5) + hash) + c;
             }
 
             return hash;
+        }
+
+        private string GetCustomExtension(string fileName)
+        {
+            var extension = fileName.EndsWith(yamlExtension, StringComparison.OrdinalIgnoreCase)
+                    ? yamlExtension
+                    : fileName.EndsWith(editorStateExtension, StringComparison.OrdinalIgnoreCase)
+                    ? editorStateExtension
+                    : Path.GetExtension(fileName);
+            return extension;
         }
     }
 }

--- a/src/PAModel/Utility/FilePath.cs
+++ b/src/PAModel/Utility/FilePath.cs
@@ -13,6 +13,9 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Utility
 {
     internal class FilePath
     {
+        private const int MAX_PATH = 260;
+        private const string yamlExtension = ".fx.yaml";
+        private const string editorStateExtension = ".editorstate.json";
         private readonly string[] _pathSegments;
 
         public FilePath(params string[] segments)
@@ -28,6 +31,29 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Utility
         public string ToPlatformPath()
         {
             return Path.Combine(_pathSegments.Select(Utilities.EscapeFilename).ToArray());
+        }
+
+        /// <summary>
+        /// Checks if the path length is more than MAX_PATH (260)
+        /// then it truncates the path, and adds a hash to the filename while retaining the file extension.
+        /// </summary>
+        /// <param name="path">Full path of the file.</param>
+        /// <returns></returns>
+        public static string ToValidPath(string path)
+        {
+            if (path.Length > MAX_PATH)
+            {
+                var extension = path.EndsWith(yamlExtension)
+                    ? yamlExtension
+                    : path.EndsWith(editorStateExtension)
+                    ? editorStateExtension
+                    : Path.GetExtension(path);
+
+                var hash = string.Format("{0:X}", path.GetHashCode());
+                path = path.Substring(0, MAX_PATH - (extension.Length + hash.Length));
+                path = string.Concat(path, hash, extension);
+            }
+            return path;
         }
 
         public static FilePath FromPlatformPath(string path)

--- a/src/PAModel/Utility/FilePath.cs
+++ b/src/PAModel/Utility/FilePath.cs
@@ -13,7 +13,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Utility
 {
     internal class FilePath
     {
-        private const int MAX_PATH = 260;
+        public const int MAX_PATH = 260;
         private const string yamlExtension = ".fx.yaml";
         private const string editorStateExtension = ".editorstate.json";
         private readonly string[] _pathSegments;

--- a/src/PAModel/Utility/Utilities.cs
+++ b/src/PAModel/Utility/Utilities.cs
@@ -36,11 +36,11 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             return list;
         }
 
-        public static void AddRange<TKey,TValue>(
+        public static void AddRange<TKey, TValue>(
             this IDictionary<TKey, TValue> thisDictionary,
             IEnumerable<KeyValuePair<TKey, TValue>> other)
         {
-            foreach(var kv in other)
+            foreach (var kv in other)
             {
                 thisDictionary[kv.Key] = kv.Value;
             }
@@ -57,7 +57,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             return @default;
         }
 
-        public static TValue GetOrCreate<TKey,TValue>(this IDictionary<TKey, TValue> dict, TKey key)
+        public static TValue GetOrCreate<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key)
             where TValue : new()
         {
             TValue value;
@@ -195,7 +195,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
         public static void EnsureNoExtraData(Dictionary<string, JsonElement> extra)
         {
-            if (extra!= null && extra.Count > 0)
+            if (extra != null && extra.Count > 0)
             {
                 throw new NotSupportedException("There are fields in json we don't recognize");
             }
@@ -239,24 +239,19 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         public static string EscapeFilename(string path)
         {
             StringBuilder sb = new StringBuilder();
-            foreach(var ch in path)
+            foreach (var ch in path)
             {
-                if (DontEscapeChar(ch))
+                var x = (int)ch;
+                if (DontEscapeChar(ch) || x > 255)
                 {
                     sb.Append(ch);
-                } else
+                }
+                else
                 {
-
-                    var x = (int)ch;
                     if (x <= 255)
                     {
                         sb.Append(EscapeChar);
                         sb.Append(x.ToString("x2"));
-                    } else
-                    {
-                        sb.Append(EscapeChar);
-                        sb.Append(EscapeChar);
-                        sb.Append(x.ToString("x4"));
                     }
                 }
             }
@@ -284,22 +279,23 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         public static string UnEscapeFilename(string path)
         {
             StringBuilder sb = new StringBuilder();
-            for(int i = 0; i < path.Length; i++)
+            for (int i = 0; i < path.Length; i++)
             {
                 var ch = path[i];
                 if (ch == EscapeChar)
                 {
                     // Unescape
                     int x;
-                    if (path[i+1] == EscapeChar)
+                    if (path[i + 1] == EscapeChar)
                     {
                         i++;
-                        x = ToHex(path[i + 1]) * 16 *16 * 16+
-                            ToHex(path[i + 2]) * 16 *16 +
+                        x = ToHex(path[i + 1]) * 16 * 16 * 16 +
+                            ToHex(path[i + 2]) * 16 * 16 +
                             ToHex(path[i + 3]) * 16 +
                             ToHex(path[i + 4]);
                         i += 4;
-                    } else
+                    }
+                    else
                     {
                         // 2 digit
                         x = ToHex(path[i + 1]) * 16 +

--- a/src/PAModelTests/FilePathTests.cs
+++ b/src/PAModelTests/FilePathTests.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.PowerPlatform.Formulas.Tools;
+using Microsoft.PowerPlatform.Formulas.Tools.Utility;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+
+namespace PAModelTests
+{
+    [TestClass]
+    public class FilePathTests
+    {
+        // If the length is more that 260 then the file name would be truncated and the new length should be 260
+        // Using escaped character to reach max path length with fewer characters.
+        [DataTestMethod]
+        [DataRow("**********************************************************************************************", FilePath.MAX_PATH)]
+        [DataRow("TestFileName.fx.yaml", 20)]
+        public void TestValidPath(string path, int expectedLength)
+        {
+            var str = FilePath.ToValidPath(Utilities.EscapeFilename(path));
+            Assert.AreEqual(str.Length, expectedLength);
+        }
+    }
+}

--- a/src/PAModelTests/FilePathTests.cs
+++ b/src/PAModelTests/FilePathTests.cs
@@ -13,14 +13,15 @@ namespace PAModelTests
     {
         // If the length of the escaped file name is beyond 60, then we truncate the length to limit it to 60.
         [DataTestMethod]
-        [DataRow("Long*Name*File*Path*Validation*Tests***.fx.yaml", FilePath.MaxFileNameLength)]
-        [DataRow("TestFileName.fx.yaml", 20)]
-        [DataRow("одиндвао", 8)] // test with unicode characters.
-        public void TestFileNames(string path, int expectedLength)
+        [DataRow("Long*Name*File*Path*Validation*Tests***.fx.yaml", FilePath.MaxFileNameLength, "Long%2aName%2aFile%2aPath%2aValidation%2aTests%2a109.fx.yaml")]
+        [DataRow("TestFileName.fx.yaml", 20, "TestFileName.fx.yaml")]
+        [DataRow("одиндвао", 8, "одиндвао")] // test with unicode characters.
+        public void TestFileNames(string path, int expectedLength, string expectedName)
         {
             var file = new FilePath(path);
             var str = file.ToPlatformPath();
             Assert.AreEqual(str.Length, expectedLength);
+            Assert.AreEqual(str, expectedName);
         }
     }
 }

--- a/src/PAModelTests/FilePathTests.cs
+++ b/src/PAModelTests/FilePathTests.cs
@@ -11,14 +11,15 @@ namespace PAModelTests
     [TestClass]
     public class FilePathTests
     {
-        // If the length is more that 260 then the file name would be truncated and the new length should be 260
-        // Using escaped character to reach max path length with fewer characters.
+        // If the length of the escaped file name is beyond 60, then we truncate the length to limit it to 60.
         [DataTestMethod]
-        [DataRow("**********************************************************************************************", FilePath.MAX_PATH)]
+        [DataRow("Long*Name*File*Path*Validation*Tests***.fx.yaml", FilePath.MaxFileNameLength)]
         [DataRow("TestFileName.fx.yaml", 20)]
-        public void TestValidPath(string path, int expectedLength)
+        [DataRow("одиндвао", 8)] // test with unicode characters.
+        public void TestFileNames(string path, int expectedLength)
         {
-            var str = FilePath.ToValidPath(Utilities.EscapeFilename(path));
+            var file = new FilePath(path);
+            var str = file.ToPlatformPath();
             Assert.AreEqual(str.Length, expectedLength);
         }
     }

--- a/src/PAModelTests/UtilityTests.cs
+++ b/src/PAModelTests/UtilityTests.cs
@@ -12,7 +12,7 @@ namespace PAModelTests
     {
         [DataTestMethod]
         [DataRow("\r\t!$^%/\\", "%0d%09%21%24%5e%25%2f%5c")]
-        [DataRow("\u4523", "%%4523")]
+        [DataRow("одиндваодиндваодиндваодиндваодиндваодинд", "одиндваодиндваодиндваодиндваодиндваодинд")]
         public void TestEscaping(string unescaped, string escaped)
         {
             Assert.AreEqual(Utilities.EscapeFilename(unescaped), escaped);
@@ -43,7 +43,7 @@ namespace PAModelTests
         [DataRow("C:\\Foo\\Bar.msapp", "C:\\", "Foo\\Bar.msapp")]
         [DataRow(@"C:\DataSources\JourneyPlanner|Sendforapproval.json", "C:\\", @"DataSources\JourneyPlanner|Sendforapproval.json")]
         [DataRow(@"C:\DataSources\JourneyPlanner%7cSendforapproval.json", "C:\\", @"DataSources\JourneyPlanner%7cSendforapproval.json")]
-        [DataRow(@"d:\app\Src\EditorState\Screen%252.editorstate.json", @"d:\app", @"Src\EditorState\Screen%252.editorstate.json" )]
+        [DataRow(@"d:\app\Src\EditorState\Screen%252.editorstate.json", @"d:\app", @"Src\EditorState\Screen%252.editorstate.json")]
         [DataRow(@"C:\Temp\MySolution\MySolution.Project\DataSources\JourneyPlanner%7cSendforapproval.json", @"C:\Temp\MySolution\MySolution.Project", @"DataSources\JourneyPlanner%7cSendforapproval.json")]
         public void TestRelativePath(string fullPath, string basePath, string expectedRelativePath)
         {


### PR DESCRIPTION
It is more likely to happen when with unicode characters, if this happens - and the full path length exceeds 260 limit, the filname would be truncated and it would be appended with a hash at the end (to avoid duplicates) while retaining the file extension.