### PR TITLE
For SaveToSources, add a flag to test round tripping.

### DIFF
--- a/src/PAModel/MsAppTest.cs
+++ b/src/PAModel/MsAppTest.cs
@@ -53,17 +53,9 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                     using (var tempDir = new TempDir())
                     {
                         string outSrcDir = tempDir.Dir;
-                        errors = msapp.SaveToSources(outSrcDir);
+                        errors = msapp.SaveToSources(outSrcDir, verifyOriginalPath : pathToMsApp);
                         errors.ThrowOnErrors();
-
-                        // Source --> Model
-                        (var msapp2, var errors2) = CanvasDocument.LoadFromSources(outSrcDir);
-                        errors2.ThrowOnErrors();
-
-                        errors2 = msapp2.SaveToMsApp(outFile); // Write out .pa files.
-                        errors2.ThrowOnErrors();
-                        var ok2 = MsAppTest.Compare(pathToMsApp, outFile, log);
-                        return ok2;
+                        return true;
                     }
                 }
             }

--- a/src/PASopa/Program.cs
+++ b/src/PASopa/Program.cs
@@ -94,34 +94,12 @@ namespace PASopa
                     return;
                 }
 
-                errors = TryOperation(() => msApp.SaveToSources(outDir));
+                errors = TryOperation(() => msApp.SaveToSources(outDir, verifyOriginalPath : msAppPath));
                 errors.Write(Console.Error);
                 if (errors.HasErrors)
                 {
                     return;
-                }
-
-                // Test that we can repack
-                {
-                    (CanvasDocument msApp2, ErrorContainer errors2) = TryOperation(() => CanvasDocument.LoadFromSources(outDir));
-                    errors2.Write(Console.Error);
-                    if (errors2.HasErrors)
-                    {
-                        return;
-                    }
-
-                    using (var temp = new TempFile())
-                    {
-                        errors2 = TryOperation(() => msApp2.SaveToMsAppValidation(temp.FullPath));
-                        errors2.Write(Console.Error);
-                        if (errors2.HasErrors)
-                        {
-                            return;
-                        }
-
-                        bool ok = MsAppTest.Compare(msAppPath, temp.FullPath, TextWriter.Null);
-                    }
-                }
+                }                
             }
             else if (mode == "-pack")
             {


### PR DESCRIPTION
This makes it easier for multiple clients to do the validation.