### PR TITLE
#194 : Changes to handle string type properties.

### DIFF
--- a/src/PAModel/Serializers/DefaultRuleHelper.cs
+++ b/src/PAModel/Serializers/DefaultRuleHelper.cs
@@ -47,7 +47,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Serializers
 
             if (_theme.TryLookup(_styleName, propertyName, out defaultScript))
             {
-                if (IsLocalizationKey(defaultScript))
+                if (ControlTemplateParser.IsLocalizationKey(defaultScript))
                     return false;
                 return true;
             }
@@ -59,7 +59,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Serializers
                 defaults.TryGetValue(propertyName, out defaultScript)) ||
                 template.InputDefaults.TryGetValue(propertyName, out defaultScript)))
             {
-                if (IsLocalizationKey(defaultScript))
+                if (ControlTemplateParser.IsLocalizationKey(defaultScript))
                     return false;
 
                 // Found in template.
@@ -89,10 +89,10 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Serializers
                 if (hasVariantDefaults)
                     defaults.AddRange(variantDefaults);
 
-                defaults.AddRange(_template.InputDefaults.Where(kvp => !IsLocalizationKey(kvp.Value) && !(hasVariantDefaults && variantDefaults.ContainsKey(kvp.Key))));
+                defaults.AddRange(_template.InputDefaults.Where(kvp => !ControlTemplateParser.IsLocalizationKey(kvp.Value) && !(hasVariantDefaults && variantDefaults.ContainsKey(kvp.Key))));
             }
 
-            defaults.AddRange(_theme.GetStyle(_styleName).Where(kvp => !IsLocalizationKey(kvp.Value)));
+            defaults.AddRange(_theme.GetStyle(_styleName).Where(kvp => !ControlTemplateParser.IsLocalizationKey(kvp.Value)));
 
             if (_inResponsiveContext)
             {
@@ -101,16 +101,5 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Serializers
 
             return defaults;
         }
-
-        // Helper to detect localization key default rules
-        // Some default rules like Label.Text are references into localization files
-        // Studio replaces them at design-time with the text from the author's current locale.
-        // We can't do that here, so we ignore localizationkey default rules when processing defaults
-        private readonly Regex _localizationRegex = new Regex("##(\\w+?)##");
-        private bool IsLocalizationKey(string rule)
-        {
-            return _localizationRegex.IsMatch(rule);
-        }
-
     }
 }

--- a/src/PAModel/SourceTransforms/DefaultValuesTransform.cs
+++ b/src/PAModel/SourceTransforms/DefaultValuesTransform.cs
@@ -14,7 +14,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
 {
     internal class DefaultValuesTransform
     {
-        private const string MultiValueDelimiterKey = "MultiValueDelimiter";
         private EditorStateStore _controlStore;
         private Theme _theme;
         private Dictionary<string, ControlTemplate> _templateStore;
@@ -86,16 +85,10 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
                     Identifier = defaultkvp.Key,
                     Expression = new ExpressionNode
                     {
-                        Expression = IsMultiValueDelimiterKey(defaultkvp.Key) ? Utilities.EscapePAString(defaultkvp.Value) : defaultkvp.Value
+                        Expression = defaultkvp.Value
                     }
                 });
             }
-        }
-
-        // MultiValueDelimiter key needs escaping since its value in the studio needs to include double quotes.
-        private bool IsMultiValueDelimiterKey(string key)
-        {
-            return key == MultiValueDelimiterKey;
         }
     }
 }

--- a/src/PAModel/SourceTransforms/DefaultValuesTransform.cs
+++ b/src/PAModel/SourceTransforms/DefaultValuesTransform.cs
@@ -14,6 +14,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
 {
     internal class DefaultValuesTransform
     {
+        private const string MultiValueDelimiterKey = "MultiValueDelimiter";
         private EditorStateStore _controlStore;
         private Theme _theme;
         private Dictionary<string, ControlTemplate> _templateStore;
@@ -85,10 +86,16 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
                     Identifier = defaultkvp.Key,
                     Expression = new ExpressionNode
                     {
-                        Expression = defaultkvp.Value
+                        Expression = IsMultiValueDelimiterKey(defaultkvp.Key) ? Utilities.EscapePAString(defaultkvp.Value) : defaultkvp.Value
                     }
                 });
             }
+        }
+
+        // MultiValueDelimiter key needs escaping since its value in the studio needs to include double quotes.
+        private bool IsMultiValueDelimiterKey(string key)
+        {
+            return key == MultiValueDelimiterKey;
         }
     }
 }

--- a/src/PAModel/Themes/Theme.cs
+++ b/src/PAModel/Themes/Theme.cs
@@ -17,7 +17,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
     internal class Theme
     {
         // Outer key is stylename, inner key is property name, inner value is expression
-        private readonly Dictionary<string, Dictionary<string, string>> _styles = new Dictionary<string, Dictionary<string, string>>();
+        private readonly Dictionary<string, Dictionary<string, string>> _styles = new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
         
         public Theme(ThemesJson themeJson)
         {


### PR DESCRIPTION
While parsing control property fs the property is of string type and 
* not an expression
* not a localizedValue
* Not a uri

Then escape double quotes to retain string literal values