### PR TITLE
#240 - Changes to avoid creation of multiple .editorState.json files for TesttSuites

### DIFF
--- a/src/PAModel/Serializers/SourceSerializer.cs
+++ b/src/PAModel/Serializers/SourceSerializer.cs
@@ -834,7 +834,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
             // We write editorstate.json file per top parent control, and hence for the TestSuite control since it is not a top parent
             // use the top parent name (i.e. Test_7F478737223C4B69) to create the editorstate.json file.
-            if (!File.Exists(Path.Combine(subDir, extraContent)))
+            if (!dir.FileExists(EditorStateDir, extraContent))
             {
                 dir.WriteAllJson(EditorStateDir, extraContent, extraData);
             }

--- a/src/PAModel/Utility/DirectoryHelper.cs
+++ b/src/PAModel/Utility/DirectoryHelper.cs
@@ -117,6 +117,18 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             System.IO.FileInfo file = new System.IO.FileInfo(path);
             file.Directory.Create(); // If the directory already exists, this method does nothing.
         }
+
+        /// <summary>
+        /// Checks if the file exists in the specified subdirectory.
+        /// </summary>
+        /// <param name="subdir">The subdirectory</param>
+        /// <param name="filename">Name of  the file.</param>
+        /// <returns>True if the file exists.</returns>
+        public bool FileExists(string subdir, string filename)
+        {
+            string path = Path.Combine(_directory, subdir, filename);
+            return File.Exists(path);
+        }
     }
 
     // Abstraction over file system. 


### PR DESCRIPTION
The File.Exists was being passed the relative path which was not correct. Added a helped method to check for existance.