### PR TITLE
Fix 252

### DIFF
--- a/src/PAModel/IR/IRStateHelpers.cs
+++ b/src/PAModel/IR/IRStateHelpers.cs
@@ -55,7 +55,13 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                     {
                         var name = customProp.Name;
                         customPropsToHide.Add(name);
-                        var expression = control.Rules.First(rule => rule.Property == name).InvariantScript;
+                        var rule = control.Rules.FirstOrDefault(rule => rule.Property == name);
+                        if (rule == null)
+                        {
+                            // Control does not have a rule for the custom property. 
+                            continue;
+                        }
+                        var expression = rule.InvariantScript;
                         var expressionNode = new ExpressionNode() { Expression = expression };
 
                         var resultType = new TypeNode() { TypeName = customProp.PropertyDataTypeKey };


### PR DESCRIPTION
Fix #252 
Controls don't necessarily have rules for all CustomProperties in a control.

Note after this, we still hit another issue with InvariantScript not round tripping (possibly #254)
 
