### PR TITLE
Make version property static for easier discoverability by consumers.

### DIFF
--- a/src/PAModel/CanvasDocument.cs
+++ b/src/PAModel/CanvasDocument.cs
@@ -27,7 +27,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         /// <summary>
         /// Current source format version. 
         /// </summary>
-        public Version CurrentSourceVersion => SourceSerializer.CurrentSourceVersion;
+        public static Version CurrentSourceVersion => SourceSerializer.CurrentSourceVersion;
 
         // Rules for CanvasDocument
         // - Save/Load must faithfully roundtrip an msapp exactly. 


### PR DESCRIPTION
It was an instance property on CanvasDocument, but that class doesn't have a public ctor either.