### PR TITLE
unrecognized hex char fix

### DIFF
--- a/src/PAModel/Utility/Utilities.cs
+++ b/src/PAModel/Utility/Utilities.cs
@@ -383,6 +383,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
         /// <summary>
         /// Truncates a string with the given length and strips off incomplete escape characters if any.
+        /// Each EscapeChar (%) must be followed by two integer values if that is not the case then it is likely that the truncation left incomplete escapes.
         /// </summary>
         /// <param name="name">The string to be truncated</param>
         /// <param name="length">The max length of the truncated string.</param>

--- a/src/PAModel/Utility/Utilities.cs
+++ b/src/PAModel/Utility/Utilities.cs
@@ -376,7 +376,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 // limit the hash to 3 characters by doing a module by 4096 (16^3)
                 var hash = (GetHash(escapedName) % 4096).ToString("x3");
                 escapedName = TruncateName(escapedName, MaxNameLength - hash.Length -1) + "_" + hash;
-
             }
             return escapedName;
         }
@@ -390,7 +389,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         /// <returns>Truncated string.</returns>
         private static string TruncateName(string name, int length)
         {
-            int removeTrailingCharsLength = name[length - 1] == EscapeChar ? 1 : name[length - 2] == EscapeChar ? 2 : 0;
+            int removeTrailingCharsLength = name[length - 1] == EscapeChar ? 1 : (name[length - 2] == EscapeChar ? 2 : 0);
             return name.Substring(0, length - removeTrailingCharsLength);
         }
 

--- a/src/PAModel/Utility/Utilities.cs
+++ b/src/PAModel/Utility/Utilities.cs
@@ -375,9 +375,22 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             {
                 // limit the hash to 3 characters by doing a module by 4096 (16^3)
                 var hash = (GetHash(escapedName) % 4096).ToString("x3");
-                escapedName = escapedName.Substring(0, MaxNameLength - (hash.Length + 1)) + "_" + hash;
+                escapedName = TruncateName(escapedName, MaxNameLength - hash.Length -1) + "_" + hash;
+
             }
             return escapedName;
+        }
+
+        /// <summary>
+        /// Truncates a string with the given length and strips off incomplete escape characters if any.
+        /// </summary>
+        /// <param name="name">The string to be truncated</param>
+        /// <param name="length">The max length of the truncated string.</param>
+        /// <returns>Truncated string.</returns>
+        private static string TruncateName(string name, int length)
+        {
+            int removeTrailingCharsLength = name[length - 1] == EscapeChar ? 1 : name[length - 2] == EscapeChar ? 2 : 0;
+            return name.Substring(0, length - removeTrailingCharsLength);
         }
 
         /// <summary>

--- a/src/PAModelTests/UtilityTests.cs
+++ b/src/PAModelTests/UtilityTests.cs
@@ -73,7 +73,7 @@ namespace PAModelTests
         }
 
         [DataTestMethod]
-        [DataRow("Long*Control*Name*Truncation*Tests***", "Long%2aControl%2aName%2aTruncation%2aTests%2a%_959")]
+        [DataRow("Long*Control*Name*Truncation*Tests***", "Long%2aControl%2aName%2aTruncation%2aTests%2a_959")]
         [DataRow("TestReallyLoooooooooooooooooooooooooooooooooooongControlName", "TestReallyLooooooooooooooooooooooooooooooooooo_cad")]
         [DataRow("TestControlName", "TestControlName")]
         public void TestControlNameTruncation(string originalName, string expectedName)


### PR DESCRIPTION
Each EscapeChar (%) must be followed by two integer values if that is not the case then it is likely that the truncation left incomplete escapes. So making a fix to remove if the string ends with % or % followed by a single digit.