### PR TITLE
screens with excaped chars fail if test steps have references for it

### DIFF
--- a/src/PAModel/Serializers/SourceSerializer.cs
+++ b/src/PAModel/Serializers/SourceSerializer.cs
@@ -354,7 +354,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 var topParentName = file._relativeName.Replace(".editorstate.json", "");
                 foreach (var control in controlExtraData)
                 {
-                    control.Value.TopParentName = topParentName;
+                    control.Value.TopParentName = Utilities.UnEscapeFilename(topParentName);
                     if (!app._editorStateStore.TryAddControl(control.Value))
                     {
                         // Can't have duplicate control names.


### PR DESCRIPTION
Fix for below error and similar types of errors

Error   PA3005: Validation error: Test Step Step22 references screen CheckBox,Toggle,Slider and Rating that is not present in the app