### PR TITLE
#201 & #249 : Screen references in tests break if entropy or editorstates are deleted

### DIFF
--- a/src/PAModel/CanvasDocument.cs
+++ b/src/PAModel/CanvasDocument.cs
@@ -373,7 +373,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 componentDefTransform.AfterRead(ctrl.Value);
             }
 
-            var transformer = new SourceTransformer(errors, templateDefaults, new Theme(_themes), componentInstanceTransform, _editorStateStore, _templateStore, _entropy);
+            var transformer = new SourceTransformer(this, errors, templateDefaults, new Theme(_themes), componentInstanceTransform, _editorStateStore, _templateStore, _entropy);
 
             foreach (var ctrl in _screens.Concat(_components))
             {
@@ -430,7 +430,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 AddComponentDefaults(ctrl.Value, templateDefaults);
             }
 
-            var transformer = new SourceTransformer(errors, templateDefaults, new Theme(_themes), componentInstanceTransform, _editorStateStore, _templateStore, _entropy);
+            var transformer = new SourceTransformer(this, errors, templateDefaults, new Theme(_themes), componentInstanceTransform, _editorStateStore, _templateStore, _entropy);
 
             foreach (var ctrl in _screens.Concat(_components))
             {

--- a/src/PAModel/CanvasDocument.cs
+++ b/src/PAModel/CanvasDocument.cs
@@ -89,6 +89,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         // Track all asset files, key is file name
         internal Dictionary<FilePath, FileEntry> _assetFiles = new Dictionary<FilePath, FileEntry>();
 
+        internal UniqueIdRestorer _idRestorer;
+
         // Tracks duplicate asset file information. When a name collision happens we generate a new name for the duplicate asset file.
         // This dictionary stores the metadata information for that file - like OriginalName, NewFileName, Path...
         // Key is a (case-insesitive) new fileName of the resource.

--- a/src/PAModel/IR/UniqueIdRestorer.cs
+++ b/src/PAModel/IR/UniqueIdRestorer.cs
@@ -25,8 +25,9 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.IR
                 return id;
             if (controlName == "App")
                 return 1;
-
-            return _nextId++;
+            var nextId = _nextId++;
+            _controlUniqueIds.Add(controlName, nextId);
+            return nextId;
         }
     }
 }

--- a/src/PAModel/Serializers/MsAppSerializer.cs
+++ b/src/PAModel/Serializers/MsAppSerializer.cs
@@ -360,6 +360,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 }
             }
 
+            app._idRestorer = new UniqueIdRestorer(app._entropy);
+
             app.ApplyAfterMsAppLoadTransforms(errors);
             app.OnLoadComplete(errors);
 

--- a/src/PAModel/Serializers/SourceSerializer.cs
+++ b/src/PAModel/Serializers/SourceSerializer.cs
@@ -261,6 +261,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             // - DynamicTypes.Json, Resources.Json , Templates.Json - could all be empty
             // - Themes.json- default to
 
+            app._idRestorer = new UniqueIdRestorer(app._entropy);
 
             app.OnLoadComplete(errors);
 

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
             return templateName == "TestSuite";
         }
 
-        public AppTestTransform(ErrorContainer errors, TemplateStore templateStore, EditorStateStore stateStore, Entropy entropy)
+        public AppTestTransform(CanvasDocument app, ErrorContainer errors, TemplateStore templateStore, EditorStateStore stateStore, Entropy entropy)
         {
             _testStepTemplateName = "TestStep";
 
@@ -43,9 +43,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
                 _testStepTemplateName = "TestStep" + i;
 
             var idRestorer = new UniqueIdRestorer(entropy);
-            _screenIdToScreenName = stateStore.Contents
-                .Where(state => state.TopParentName == state.Name)
-                .Select(state => new KeyValuePair<string, string>(idRestorer.GetControlId(state.Name).ToString(), state.Name)).ToList();
+            _screenIdToScreenName = app._screens
+                .Select(screen => new KeyValuePair<string, string>(idRestorer.GetControlId(screen.Key).ToString(), screen.Key)).ToList();
 
             _errors = errors;
         }

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -42,9 +42,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
             while (templateStore.TryGetTemplate(_testStepTemplateName, out _))
                 _testStepTemplateName = "TestStep" + i;
 
-            var idRestorer = new UniqueIdRestorer(entropy);
             _screenIdToScreenName = app._screens
-                .Select(screen => new KeyValuePair<string, string>(idRestorer.GetControlId(screen.Key).ToString(), screen.Key)).ToList();
+                .Select(screen => new KeyValuePair<string, string>(app._idRestorer.GetControlId(screen.Key).ToString(), screen.Key)).ToList();
 
             _errors = errors;
         }

--- a/src/PAModel/SourceTransforms/SourceTransformer.cs
+++ b/src/PAModel/SourceTransforms/SourceTransformer.cs
@@ -22,12 +22,12 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
 
         internal DefaultValuesTransform _defaultValTransform;
 
-        public SourceTransformer(ErrorContainer errors, Dictionary<string, ControlTemplate> defaultValueTemplates, Theme theme, ComponentInstanceTransform componentInstanceTransform,
+        public SourceTransformer(CanvasDocument app, ErrorContainer errors, Dictionary<string, ControlTemplate> defaultValueTemplates, Theme theme, ComponentInstanceTransform componentInstanceTransform,
             EditorStateStore stateStore, TemplateStore templateStore, Entropy entropy)
         {
             _templateTransforms = new List<IControlTemplateTransform>();
             _templateTransforms.Add(new GalleryTemplateTransform(defaultValueTemplates, stateStore));
-            _templateTransforms.Add(new AppTestTransform(errors, templateStore, stateStore, entropy));
+            _templateTransforms.Add(new AppTestTransform(app, errors, templateStore, stateStore, entropy));
             _templateTransforms.Add(componentInstanceTransform);
 
             _groupControlTransform = new GroupControlTransform(errors, stateStore, entropy);

--- a/src/PAModelTests/AppTestsTest.cs
+++ b/src/PAModelTests/AppTestsTest.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.PowerPlatform.Formulas.Tools;
+using Microsoft.PowerPlatform.Formulas.Tools.Utility;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+
+namespace PAModelTests
+{
+    // DataSources Tests
+    [TestClass]
+    public class AppTestsTest
+    {
+        // Validates that the App can be repacked after deleting the EditorState files, when the app contains app tests which refer to screens.
+        [DataTestMethod]
+        [DataRow("TestStudio_Test.msapp")]
+        public void TestPackWhenEditorStateIsDeleted(string appName)
+        {
+            var root = Path.Combine(Environment.CurrentDirectory, "Apps", appName);
+            Assert.IsTrue(File.Exists(root));
+
+            (var msapp, var errors) = CanvasDocument.LoadFromMsapp(root);
+            errors.ThrowOnErrors();
+
+            using (var tempDir = new TempDir())
+            {
+                string outSrcDir = tempDir.Dir;
+
+                // Save to sources
+                msapp.SaveToSources(outSrcDir);
+
+                // Delete Entropy directory
+                var editorStatePath = Path.Combine(outSrcDir, "Src", "EditorState");
+                if (Directory.Exists(editorStatePath))
+                {
+                    Directory.Delete(editorStatePath, true);
+                }
+
+                // Load app from the sources after deleting the entropy
+                var app = SourceSerializer.LoadFromSource(outSrcDir, new ErrorContainer());
+
+                using (var tempFile = new TempFile())
+                {
+                    // Repack the app
+                    MsAppSerializer.SaveAsMsApp(app, tempFile.FullPath, new ErrorContainer());
+                }
+            }
+        }
+
+        // Validates that the App can be repacked after deleting the Entropy files, when the app contains app tests which refer to screens.
+        [DataTestMethod]
+        [DataRow("TestStudio_Test.msapp")]
+        public void TestPackWhenEntropyIsDeleted(string appName)
+        {
+            var root = Path.Combine(Environment.CurrentDirectory, "Apps", appName);
+            Assert.IsTrue(File.Exists(root));
+
+            (var msapp, var errors) = CanvasDocument.LoadFromMsapp(root);
+            errors.ThrowOnErrors();
+
+            using (var tempDir = new TempDir())
+            {
+                string outSrcDir = tempDir.Dir;
+
+                // Save to sources
+                msapp.SaveToSources(outSrcDir);
+
+                // Delete Entropy directory
+                var entropyPath = Path.Combine(outSrcDir, "Entropy");
+                if (Directory.Exists(entropyPath))
+                {
+                    Directory.Delete(entropyPath, true);
+                }
+
+                // Load app from the sources after deleting the entropy
+                var app = SourceSerializer.LoadFromSource(outSrcDir, new ErrorContainer());
+
+                using (var tempFile = new TempFile())
+                {
+                    // Repack the app
+                    MsAppSerializer.SaveAsMsApp(app, tempFile.FullPath, new ErrorContainer());
+
+                    // re-unpack should succeed
+                    (var msapp1, var errors1) = CanvasDocument.LoadFromMsapp(tempFile.FullPath);                    
+                    msapp1.SaveToSources(new TempDir().Dir);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Made the changes to read the screen names from app._screens rather than reading them from stateStore.
Also updated the logic to store screen index when entropy is deleted