### PR TITLE
Normalize \r style multiline properties correctly

### DIFF
--- a/src/PAModel/PAConvert/Yaml/YamlWriter.cs
+++ b/src/PAModel/PAConvert/Yaml/YamlWriter.cs
@@ -62,6 +62,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Yaml
                 return;
             }
 
+            value = NormalizeNewlines(value);
+
             bool isSingleLine = value.IndexOfAny(new char[] { '#', '\n', ':' }) == -1;
 
             // For consistency, both single and multiline PA properties prefix with '='.
@@ -111,12 +113,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Yaml
                         needIndent = false;
                     }
 
-                    if (ch == '\r')
-                    {
-                        // skip and handle at the \n
-                        continue; 
-                    }
-
                     if (ch == '\n')
                     {
                         _text.WriteLine();
@@ -148,6 +144,11 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Yaml
             {
                 _text.Write(Indent);
             }
+        }
+
+        public static string NormalizeNewlines(string x)
+        {
+            return x.Replace("\r\n", "\n").Replace("\r", "\n");
         }
     }
 }

--- a/src/PAModelTests/YamlTest.cs
+++ b/src/PAModelTests/YamlTest.cs
@@ -63,13 +63,16 @@ Obj1:
         [DataTestMethod]
         [DataRow("  1")] // leading whitespace
         [DataRow("  1\n2\n3")] // leading whitespace with multiline
+        [DataRow("  1\r2\r3")] // leading whitespace with Mac style multiline
         [DataRow("12 + \r\n\r\n34")]
         [DataRow("abc\r\ndef")]
+        [DataRow("abc\rdef")] // MacOS style multiline
         [DataRow("\"brows_4.0\"")]
         [DataRow("a # b")] // Test with yaml comment. 
         [DataRow("x")] // easy, no newlines. 
         [DataRow("1\n2")] // multiline
         [DataRow("1\n2\n")] // multiline, trailing newline
+        [DataRow("1\n2\r3\r\n")] // Mixed multiline
         [DataRow("1 \n2 \n")] 
         [DataRow("1\n 2 \n ")]
         [DataRow("1\n2 \n ")]

--- a/src/PAModelTests/YamlTest.cs
+++ b/src/PAModelTests/YamlTest.cs
@@ -71,6 +71,12 @@ Obj1:
         [DataRow("a # b")] // Test with yaml comment. 
         [DataRow("x")] // easy, no newlines. 
         [DataRow("1\n2")] // multiline
+        [DataRow("1\n\n2")] // 2 lines linux
+        [DataRow("1\r\r2")] // 2 lines mac
+        [DataRow("1\r\n\r\n2")] // 2 lines windows
+        [DataRow("1\r\n\r2")] // 2 lines mixed
+        [DataRow("1\n\r\n2")] // 2 lines mixed
+        [DataRow("1\n\r2")] // 2 lines mixed
         [DataRow("1\n2\n")] // multiline, trailing newline
         [DataRow("1\n2\r3\r\n")] // Mixed multiline
         [DataRow("1 \n2 \n")] 


### PR DESCRIPTION
fixes #289 