### PR TITLE
Add properties for the components tabstop fix

### DIFF
--- a/src/PAModel/ControlTemplates/GlobalTemplates.cs
+++ b/src/PAModel/ControlTemplates/GlobalTemplates.cs
@@ -41,7 +41,10 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.ControlTemplates
                 });
             }
 
-            templates.Add("groupContainer", CreateGroupContainerTemplate(type));
+            if (!templates.ContainsKey("groupContainer"))
+            {
+                templates.Add("groupContainer", CreateGroupContainerTemplate(type));
+            }
             if (!templateStore.TryGetTemplate("groupContainer", out _))
             {
                 templateStore.AddTemplate("groupContainer", new CombinedTemplateState()

--- a/src/PAModel/ControlTemplates/GlobalTemplates.cs
+++ b/src/PAModel/ControlTemplates/GlobalTemplates.cs
@@ -41,6 +41,10 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.ControlTemplates
                 });
             }
 
+            /*  Prior to PAC Document version 1.318, the groupContainer control was not version
+                flexible, so we must check for its existence here. These can be removed from
+                GlobalTemplates IFF all documents are upgraded to 1.318+ (unlikely) OR if support
+                for documents 1.317 and lower is dropped. */
             if (!templates.ContainsKey("groupContainer"))
             {
                 templates.Add("groupContainer", CreateGroupContainerTemplate(type));
@@ -99,6 +103,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.ControlTemplates
             template.InputDefaults.Add("X", "0");
             template.InputDefaults.Add("Y", "0");
             template.InputDefaults.Add("Visible", "true");
+            template.InputDefaults.Add("ChildTabPriority", "true");
+            template.InputDefaults.Add("EnableChildFocus", "true");
 
 
             // These share a lot of properties, and they should be in the base template, but this is

--- a/src/PAModel/ControlTemplates/commonStyleProperties.xml
+++ b/src/PAModel/ControlTemplates/commonStyleProperties.xml
@@ -591,4 +591,19 @@
     <appMagic:displayName>##CommonProperties_ContentLanguage_DisplayName##</appMagic:displayName>
     <appMagic:tooltip>##CommonProperties_ContentLanguage_Tooltip##</appMagic:tooltip>
   </property>
+
+  <property name="ChildTabPriority" localizedName="##ChildTabPriority##" datatype="Boolean" defaultValue="true">
+    <title>Prioritize child controls</title>
+    <appMagic:category>design</appMagic:category>
+    <appMagic:helperUI>childTabPriority</appMagic:helperUI>
+    <appMagic:displayName>##CommonProperties_ChildTabPriority_DisplayName##</appMagic:displayName>
+    <appMagic:tooltip>##CommonProperties_ChildTabPriority_Tooltip##</appMagic:tooltip>
+  </property>
+  <property name="EnableChildFocus" localizedName="##EnableChildFocus##" datatype="Boolean" defaultValue="true">
+    <title>Enable child control focus</title>
+    <appMagic:category>design</appMagic:category>
+    <appMagic:helperUI>enableChildFocus</appMagic:helperUI>
+    <appMagic:displayName>##CommonProperties_EnableChildFocus_DisplayName##</appMagic:displayName>
+    <appMagic:tooltip>##CommonProperties_EnableChildFocus_Tooltip##</appMagic:tooltip>
+  </property>
 </properties>


### PR DESCRIPTION
This PR adds new properties being added to the common style properties in an internal PR to PowerApps Client, and also adds a check for the groupContainer in GlobalTemplates.cs. It's not clear to me _why_ the new changes in PAC are triggering the groupContainer to now be included, but we already have several work items to investigate the inconsistencies in the template versioning pipeline.