### PR TITLE
Fix "'0x00' is invalid within a JSON string." exception from 'Load' m…

### DIFF
--- a/src/PAModel/Utility/Utilities.cs
+++ b/src/PAModel/Utility/Utilities.cs
@@ -134,9 +134,15 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             using (var s = e.Open())
             {
                 // Non-seekable stream.
-                var len = e.Length;
-                var buffer = new byte[len];
-                s.Read(buffer, 0, (int)len);
+                var buffer = new byte[e.Length];
+                int bytesRead = 0;
+
+                do
+                {
+                    bytesRead += s.Read(buffer, bytesRead, (int) e.Length-bytesRead);
+                } while (bytesRead < e.Length);
+
+
                 return buffer;
             }
         }


### PR DESCRIPTION
…ethod when running on .NET 6

Running on .NET introduces a bug when the library calculates file checksums. This causes the exception above under some conditions (file size > some threshold ?).

I have looked into it and it's because the method in this PR doesn't correctly check the return value for Read method that indicates if all requested bytes have been read or not. This results in a byte array being return which has some of the bytes missing and are hence the default null bytes are returned instead. These bytes are then parsed into JsonDocument in CheckSumMaker, and this causes the exception.

The PR fixes this and correctly loops until the whole file contents have been read from the zip entry.