### PR TITLE
Update to support addition of AllowAccessToGlobals property on component definition

### DIFF
--- a/src/PAModel/EditorState/CombinedTemplateState.cs
+++ b/src/PAModel/EditorState/CombinedTemplateState.cs
@@ -36,6 +36,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.EditorState
         public string TemplateOriginalName { get; set; } = null;
         public ComponentType? ComponentType { get; set; } = null;
 
+        [JsonIgnore]
+        public bool? AllowAccessToGlobals { get; set; } = null;
 
         // Present on PCF
         public string TemplateDisplayName { get; set; } = null;
@@ -66,6 +68,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.EditorState
             Version = template.Version;
             LastModifiedTimestamp = template.LastModifiedTimestamp;
             ComponentDefinitionInfo = null;
+            AllowAccessToGlobals = template.ComponentDefinitionInfo?.AllowAccessToGlobals;
             IsComponentTemplate = template.IsComponentDefinition;
             CustomProperties = template.CustomProperties;
             TemplateDisplayName = template.TemplateDisplayName;

--- a/src/PAModel/IR/IRStateHelpers.cs
+++ b/src/PAModel/IR/IRStateHelpers.cs
@@ -341,9 +341,11 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
                 if (state.IsComponentDefinition ?? false)
                 {
-                    templateState.ComponentDefinitionInfo = new ComponentDefinitionInfoJson(resultControlInfo, template.LastModifiedTimestamp, orderedChildren);
+                    templateState.ComponentDefinitionInfo = new ComponentDefinitionInfoJson(resultControlInfo, template.LastModifiedTimestamp, orderedChildren, templateState.AllowAccessToGlobals);
                     template = templateState.ToControlInfoTemplate();
                     template.IsComponentDefinition = true;
+
+                    // Set it null so that it can be ignored. We have this information at other place.
                     template.ComponentDefinitionInfo = null;
                 }
                 else

--- a/src/PAModel/Schemas/DataComponentDefinitionJson.cs
+++ b/src/PAModel/Schemas/DataComponentDefinitionJson.cs
@@ -72,18 +72,20 @@ namespace Microsoft.AppMagic.Authoring.Persistence
         public string LastModifiedTimestamp { get; set; } //  "637335420246436668",
         public ControlInfoJson.RuleEntry[] Rules {get;set;}
         public ControlInfoJson.Item[] Children { get; set; }
+        public bool? AllowAccessToGlobals { get; set; }
 
         [JsonExtensionData]
         public Dictionary<string, object> ExtensionData { get; set; }
 
         public ComponentDefinitionInfoJson() { }
 
-        public ComponentDefinitionInfoJson(ControlInfoJson.Item item, string timestamp, ControlInfoJson.Item[] children)
+        public ComponentDefinitionInfoJson(ControlInfoJson.Item item, string timestamp, ControlInfoJson.Item[] children, bool? allowAccessToGlobals)
         {
             Name = item.Name;
             LastModifiedTimestamp = timestamp;
             Rules = item.Rules;
             Children = children;
+            AllowAccessToGlobals = allowAccessToGlobals;
 
             // Once ControlPropertyState has an actual schema, this can be cleaned up.
             if (item.ExtensionData.ContainsKey("ControlPropertyState"))

--- a/src/PAModel/Schemas/adhoc/Control.cs
+++ b/src/PAModel/Schemas/adhoc/Control.cs
@@ -44,7 +44,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             public string Version { get; set; }
             public string LastModifiedTimestamp {get;set;}
 
-            // Used with templates. 
+            // Used with templates.
             public bool? IsComponentDefinition { get; set; }
             public ComponentDefinitionInfoJson ComponentDefinitionInfo { get; set; }
 


### PR DESCRIPTION
- Add AllowAccessToGlobals property on ComponentDefinitionInfoJson.
- Updates to IRStateHelper to use this property value.

