### PR TITLE
Dynamic Property NullCheck

### DIFF
--- a/src/PAModel/IR/IRStateHelpers.cs
+++ b/src/PAModel/IR/IRStateHelpers.cs
@@ -503,6 +503,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             DynamicPropertyState propState = null;
             if (state.DynamicProperties.ToDictionary(prop => prop.PropertyName).TryGetValue(propName, out propState))
             {
+                //The DynamicProperties may contain items without an existing corresponding property leading to empty property variables
                 if (propState.Property != null)
                 {
                     property.Rule = new ControlInfoJson.RuleEntry()

--- a/src/PAModel/IR/IRStateHelpers.cs
+++ b/src/PAModel/IR/IRStateHelpers.cs
@@ -503,15 +503,18 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             DynamicPropertyState propState = null;
             if (state.DynamicProperties.ToDictionary(prop => prop.PropertyName).TryGetValue(propName, out propState))
             {
-                property.Rule = new ControlInfoJson.RuleEntry()
+                if (propState.Property != null)
                 {
-                    InvariantScript = expression,
-                    Property = propName,
-                    ExtensionData = propState.Property.ExtensionData,
-                    NameMap = propState.Property.NameMap,
-                    RuleProviderType = propState.Property.RuleProviderType
-                };
-                property.ExtensionData = propState.ExtensionData;
+                    property.Rule = new ControlInfoJson.RuleEntry()
+                    {
+                        InvariantScript = expression,
+                        Property = propName,
+                        ExtensionData = propState.Property.ExtensionData,
+                        NameMap = propState.Property.NameMap,
+                        RuleProviderType = propState.Property.RuleProviderType
+                    };
+                    property.ExtensionData = propState.ExtensionData;
+                }
             }
             else
             {


### PR DESCRIPTION
Null check to prevent exceptions generated during yaml to .msapp conversion due to default dynamic properties generated. 