### PR TITLE
Resolve editor state name conflicts during serialization

### DIFF
--- a/src/PAModel/EditorState/ControlState.cs
+++ b/src/PAModel/EditorState/ControlState.cs
@@ -1,7 +1,4 @@
-using Microsoft.PowerPlatform.Formulas.Tools.EditorState;
-using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.PowerPlatform.Formulas.Tools.EditorState
@@ -14,12 +11,11 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.EditorState
     {
         public string Name { get; set; }
 
-        [JsonIgnore]
         public string TopParentName { get; set; }
 
         // These are properties with namemaps/info beyond the ones present in the control template
         // Key is property name
-        public List<PropertyState> Properties { get; set; } 
+        public List<PropertyState> Properties { get; set; }
 
         // These are properties specific to AutoLayout controls
         public List<DynamicPropertyState> DynamicProperties { get; set; }

--- a/src/PAModel/Serializers/SourceSerializer.cs
+++ b/src/PAModel/Serializers/SourceSerializer.cs
@@ -45,7 +45,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         // 22 - AppTest is sharded into individual TestSuite.fx.yaml files in Src/Tests directory.
         // 23 - Unicodes are allowed to be part of filename and the filename is limited to 60 characters length, if it's more then it gets truncated.
         // 24 - Sharding PCF control templates in pkgs/PcfControlTemplates directory and checksum update.
-        // 25 - When loading in sources, use the TopParentControl from the ediot state, if it was serialized.
+        // 25 - When loading in sources, use the TopParentControl from the serialized editor state.
         public static Version CurrentSourceVersion = new Version(0, 25);
 
         // Layout is:
@@ -357,16 +357,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
                 // Json peer to a .pa file. 
                 var controlExtraData = file.ToObject<Dictionary<string, ControlState>>();
-                var topParentFilename = file._relativeName.Replace(".editorstate.json", "");
                 foreach (var control in controlExtraData)
                 {
-                    // For backwards compat purposes. We may not have the TopParentName from
-                    // the editor state file. In this case, revert back to the filename itself.
-                    if (string.IsNullOrEmpty(control.Value.TopParentName))
-                    {
-                        control.Value.TopParentName = Utilities.UnEscapeFilename(topParentFilename);
-                    }
-
                     if (!app._editorStateStore.TryAddControl(control.Value))
                     {
                         // Can't have duplicate control names.


### PR DESCRIPTION
Fixes an issue where controls with the same case-insensitive names can conflict on the file system when generating `editorstate.json` files for the control. This uses the existing name collision handling logic to generate a new filename when needed.

This introduces a case where, when loading in the source files, the `TopParentName` of a control may be set incorrectly, due to the reliance on the filename. This change updates the `ControlState` object to store the `TopParentName` in the appropriate `editorstate.json` during serialization. When loading sources, the `TopParentName` will now be present on the `ControlState` and the filename does not matter.

This change increments the SourceSerializer's version number.