### PR TITLE
Fixing recommended VS Code extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,6 @@
     "davidanson.vscode-markdownlint",
     "eamodio.gitlens",
     "ms-azure-devops.azure-pipelines",
-    "ms-vscode.csharp"
+    "ms-dotnettools.csharp"
   ]
 }


### PR DESCRIPTION
Updating the recommended VS Code extensions since `ms-vscode.csharp` has been renamed to `ms-dotnettools.csharp`.