### PR TITLE
Handling dynamic properties default value in defaultValueTransform

### DIFF
--- a/src/PAModel/SourceTransforms/DefaultValuesTransform.cs
+++ b/src/PAModel/SourceTransforms/DefaultValuesTransform.cs
@@ -62,7 +62,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
             {
                 styleName = controlState.StyleName;
                 propNames = new HashSet<string>(controlState.Properties.Select(state => state.PropertyName)
-                    .Concat(controlState.DynamicProperties?.Select(state => state.PropertyName) ?? Enumerable.Empty<string>()));
+                    .Concat(controlState.DynamicProperties?.Where(state => state.Property != null).Select(state => state.PropertyName) ?? Enumerable.Empty<string>()));
             }
 
             ControlTemplate template;


### PR DESCRIPTION
Roundtrip failed while unpacking the .msapp with fluidGrid container #300
Problem seems to be
- hash mismatch because of dynamic property with null values included in control jsons.
![image](https://user-images.githubusercontent.com/98551644/154725301-06054294-56fd-430c-a2a5-457a0238988f.png)

Solution
-By fixing the way dynamic property with null value is handled in src\PAModel\SourceTransforms\DefaultValuesTransform.cs
