### PR TITLE
Issue 308: Removing Validation For Missing Data Source

### DIFF
--- a/src/PAModel/CanvasDocument.cs
+++ b/src/PAModel/CanvasDocument.cs
@@ -501,15 +501,15 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                     errors.FormatNotSupported($"Document consistency error. Connection id mismatch");
                     throw new DocumentException();
                 }
-                foreach (var dataSourceName in connection.dataSources ?? Enumerable.Empty<string>())
-                {
-                    var ds = _dataSources.SelectMany(x => x.Value).Where(x => x.Name == dataSourceName).FirstOrDefault();
-                    if (ds == null)
-                    {
-                        errors.ValidationError($"Connection '{dataSourceName}' does not have a corresponding data source.");
-                        throw new DocumentException();
-                    }
-                }
+                // foreach (var dataSourceName in connection.dataSources ?? Enumerable.Empty<string>())
+                // {
+                //     var ds = _dataSources.SelectMany(x => x.Value).Where(x => x.Name == dataSourceName).FirstOrDefault();
+                //     if (ds == null)
+                //     {
+                //         errors.ValidationError($"Connection '{dataSourceName}' does not have a corresponding data source.");
+                //         throw new DocumentException();
+                //     }
+                // }
             }
         }
 

--- a/src/PAModel/CanvasDocument.cs
+++ b/src/PAModel/CanvasDocument.cs
@@ -490,8 +490,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             }
 
 
-            // Integrity checks. 
-            // Make sure every connection has a corresponding data source. 
+            // Integrity checks.
             foreach (var kv in _connections.NullOk())
             {
                 var connection = kv.Value;

--- a/src/PAModel/CanvasDocument.cs
+++ b/src/PAModel/CanvasDocument.cs
@@ -501,15 +501,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                     errors.FormatNotSupported($"Document consistency error. Connection id mismatch");
                     throw new DocumentException();
                 }
-                // foreach (var dataSourceName in connection.dataSources ?? Enumerable.Empty<string>())
-                // {
-                //     var ds = _dataSources.SelectMany(x => x.Value).Where(x => x.Name == dataSourceName).FirstOrDefault();
-                //     if (ds == null)
-                //     {
-                //         errors.ValidationError($"Connection '{dataSourceName}' does not have a corresponding data source.");
-                //         throw new DocumentException();
-                //     }
-                // }
             }
         }
 


### PR DESCRIPTION
Problem:
Issue originally documented here: https://github.com/microsoft/PowerApps-Language-Tooling/issues/308 . When Properties.json is missing a table for a specific corresponding Data Source, it will cause this issue and refuse to unpack. However, it does not seem necessary for this validation error to be thrown because there is no roundtrip error otherwise.

Solution:
Remove the code that throws this validation error.