### PR TITLE
Bring ParameterSchema in line with PowerFx FormulaTypeSchema

### DIFF
--- a/src/PAModel/Schemas/ParameterSchema.cs
+++ b/src/PAModel/Schemas/ParameterSchema.cs
@@ -18,26 +18,46 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Schemas
             Date,
             Time,
             DateTime,
+            DateTimeNoTimeZone,
             Color,
             Guid,
             Record,
             Table,
+            Blank,
+            Hyperlink,
+            OptionSetValue,
+            UntypedObject,
             EntityRecord,
             EntityTable,
         }
 
+        // Keep in sync with and eventually depend on Power-Fx/src/libraries/Microsoft.PowerFx.Core/Public/Types/Serialization/FormulaTypeSchema.cs
         public class Parameter
         {
+            /// <summary>
+            /// Represents the type of this item. For some complex types, additional optional data is required.
+            /// </summary>
             public ParamType Type { get; set; }
 
-            public bool Required { get; set; }
+            /// <summary>
+            /// Optional. For Records and Tables, contains the list of fields.
+            /// </summary>
+            public Dictionary<string, Parameter> Fields { get; set; }
 
-            // Optional: For EntityRecord and EntityTable, specifies the logical name of the table
-            // that the type is derived from
+            /// <summary>
+            /// Optional. Used for external schema definitions and input validation.
+            /// </summary>
+            public bool? Required { get; set; }
+
+            /// <summary>
+            /// Optional. For entities, specifies the table logical name.
+            /// </summary>
             public string TableLogicalName { get; set; }
 
-            // Optional: For records, can become recursive
-            public Dictionary<string, Parameter> Fields { get; set; }
+            /// <summary>
+            /// Optional. For Option Set Values, specifies the option set logical name.
+            /// </summary>
+            public string OptionSetName { get; set; }
         }
 
         // Input parameters (public)


### PR DESCRIPTION
Unifying definitions with https://github.com/microsoft/Power-Fx/pull/215

Eventually, we'll update this tool to depend on PowerFx and pull the definition directly.