### PR TITLE
Draft: Github issue 191 (validation in themes.json)

### DIFF
--- a/src/PAModel/CanvasDocument.cs
+++ b/src/PAModel/CanvasDocument.cs
@@ -384,7 +384,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 componentDefTransform.AfterRead(ctrl.Value);
             }
 
-            var transformer = new SourceTransformer(this, errors, templateDefaults, new Theme(_themes), componentInstanceTransform, _editorStateStore, _templateStore, _entropy);
+            var transformer = new SourceTransformer(this, errors, templateDefaults, new Theme(_themes, errors), componentInstanceTransform, _editorStateStore, _templateStore, _entropy);
 
             foreach (var ctrl in _screens.Concat(_components))
             {
@@ -441,7 +441,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 AddComponentDefaults(ctrl.Value, templateDefaults);
             }
 
-            var transformer = new SourceTransformer(this, errors, templateDefaults, new Theme(_themes), componentInstanceTransform, _editorStateStore, _templateStore, _entropy);
+            var transformer = new SourceTransformer(this, errors, templateDefaults, new Theme(_themes, errors), componentInstanceTransform, _editorStateStore, _templateStore, _entropy);
 
             foreach (var ctrl in _screens.Concat(_components))
             {

--- a/src/PAModel/PAConvert/ErrorCode.cs
+++ b/src/PAModel/PAConvert/ErrorCode.cs
@@ -56,9 +56,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         // Bad parameter (such as a missing file)
         BadParameter= 3012, 
 
-        // If themes.json has empty string values for default scripts
-        ThemesEmptyString = 3013,
-
         // Catch-all.  Should review and make these more specific. 
         Generic = 3999,
 
@@ -157,11 +154,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         public static void BadParameter(this ErrorContainer errors, string message)
         {
             errors.AddError(ErrorCode.BadParameter, default(SourceLocation), $"Bad parameter: {message}");
-        }
-
-        public static void ThemesEmptyString(this ErrorContainer errors)
-        {
-            errors.AddError(ErrorCode.ThemesEmptyString, default(SourceLocation), $"Themes.json contains a default script of empty string.");
         }
     }
 }

--- a/src/PAModel/PAConvert/ErrorCode.cs
+++ b/src/PAModel/PAConvert/ErrorCode.cs
@@ -62,6 +62,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         // Some of the cases which the tool doesn't support, see below example:
         // Connection Accounts is using the old CDS connector which is incompatable with this tool
         UnsupportedError = 4001
+        
     }
 
     internal static class ErrorCodeExtensions

--- a/src/PAModel/PAConvert/ErrorCode.cs
+++ b/src/PAModel/PAConvert/ErrorCode.cs
@@ -62,7 +62,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         // Some of the cases which the tool doesn't support, see below example:
         // Connection Accounts is using the old CDS connector which is incompatable with this tool
         UnsupportedError = 4001
-        
+
     }
 
     internal static class ErrorCodeExtensions

--- a/src/PAModel/PAConvert/ErrorCode.cs
+++ b/src/PAModel/PAConvert/ErrorCode.cs
@@ -56,13 +56,15 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         // Bad parameter (such as a missing file)
         BadParameter= 3012, 
 
+        // If themes.json has empty string values for default scripts
+        ThemesEmptyString = 3013,
+
         // Catch-all.  Should review and make these more specific. 
         Generic = 3999,
 
         // Some of the cases which the tool doesn't support, see below example:
         // Connection Accounts is using the old CDS connector which is incompatable with this tool
         UnsupportedError = 4001
-
     }
 
     internal static class ErrorCodeExtensions
@@ -155,6 +157,11 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         public static void BadParameter(this ErrorContainer errors, string message)
         {
             errors.AddError(ErrorCode.BadParameter, default(SourceLocation), $"Bad parameter: {message}");
+        }
+
+        public static void ThemesEmptyString(this ErrorContainer errors)
+        {
+            errors.AddError(ErrorCode.ThemesEmptyString, default(SourceLocation), $"Themes.json contains a default script of empty string.");
         }
     }
 }

--- a/src/PAModel/Themes/Theme.cs
+++ b/src/PAModel/Themes/Theme.cs
@@ -48,7 +48,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 var styleName = style.name;
                 foreach (var prop in style.propertyValuesMap)
                 {
-                    if(prop.value == ""){
+                    if (prop.value == "")
+                    {
                         errors.ValidationError($"Themes.json cannot contain a default script of empty string.");
                     }
 

--- a/src/PAModel/Themes/Theme.cs
+++ b/src/PAModel/Themes/Theme.cs
@@ -19,10 +19,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         // Outer key is stylename, inner key is property name, inner value is expression
         private readonly Dictionary<string, Dictionary<string, string>> _styles = new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
         
-        public (ErrorContainer) Theme(ThemesJson themeJson)
+        public Theme(ThemesJson themeJson, ErrorContainer errors)
         {
-            var errors = new ErrorContainer();
-
             Contract.Assert(themeJson != null);
 
             var currentThemeName = themeJson.CurrentTheme;

--- a/src/PAModel/Themes/Theme.cs
+++ b/src/PAModel/Themes/Theme.cs
@@ -19,21 +19,23 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         // Outer key is stylename, inner key is property name, inner value is expression
         private readonly Dictionary<string, Dictionary<string, string>> _styles = new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
         
-        public Theme(ThemesJson themeJson)
+        public (ErrorContainer) Theme(ThemesJson themeJson)
         {
+            var errors = new ErrorContainer();
+
             Contract.Assert(themeJson != null);
 
             var currentThemeName = themeJson.CurrentTheme;
             var namedThemes = themeJson.CustomThemes.ToDictionary(theme => theme.name);
             if (namedThemes.TryGetValue(currentThemeName, out var foundTheme))
             {
-                LoadTheme(foundTheme);
+                LoadTheme(foundTheme, errors);
             }
             
         }
 
 
-        private void LoadTheme(CustomThemeJson theme)
+        private void LoadTheme(CustomThemeJson theme, ErrorContainer errors)
         {
             Dictionary<string, string> palleteRules = new Dictionary<string, string>();
             foreach (var item in theme.palette)
@@ -47,7 +49,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 foreach (var prop in style.propertyValuesMap)
                 {
                     if(prop.value == ""){
-                        throw new ArgumentException("Themes.json contains a default script of empty string");
+                        errors.ValidationError($"Themes.json cannot contain a default script of empty string.");
                     }
 
                     var propName = prop.property;

--- a/src/PAModel/Themes/Theme.cs
+++ b/src/PAModel/Themes/Theme.cs
@@ -46,6 +46,10 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 var styleName = style.name;
                 foreach (var prop in style.propertyValuesMap)
                 {
+                    if(prop.value == ""){
+                        throw new ArgumentException("Themes.json contains a default script of empty string");
+                    }
+
                     var propName = prop.property;
                     var ruleValue = prop.value;
 
@@ -56,8 +60,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                         if (match.Success)
                         {
                             var group = match.Groups[1];
-
-
 
                             string resourceValue;
                             // Template may refer to a missing rule. 

--- a/src/PAModelTests/DefaultValuesTransformTests.cs
+++ b/src/PAModelTests/DefaultValuesTransformTests.cs
@@ -22,7 +22,7 @@ namespace PAModelTests
         //Testing the DefaultValuesTransform:beforeWrite() behaviour on control node with null dynamic properties
         //Specifically cases where property null but propertynames not null
         [TestMethod]
-        public void TestCaseWithNullDynamicProperties()
+        public void TestCaseWithNullDynamicProperties(ErrorContainer errors)
         {
             //creating a BlockNode with a single property
             var newNode = new BlockNode()
@@ -35,7 +35,7 @@ namespace PAModelTests
                 Properties = new List<PropertyNode>() { new PropertyNode { Identifier = "SomeProp", Expression = new ExpressionNode() { Expression = "Expr" } } }
             };
 
-            var defaultValTransform = new DefaultValuesTransform(getTemplateStore(), getTheme(), getEditorStateStore());
+            var defaultValTransform = new DefaultValuesTransform(getTemplateStore(), getTheme(errors), getEditorStateStore());
 
             defaultValTransform.BeforeWrite(newNode, false);
 
@@ -79,12 +79,12 @@ namespace PAModelTests
             return editorStateStore;
         }
 
-        private Theme getTheme()
+        private Theme getTheme(ErrorContainer errors)
         {
             var CustomTheme = new CustomThemeJson() { name = "SomeCustomTheme" };
             var themeJson = new ThemesJson() { CurrentTheme = "SomeTheme", CustomThemes = new[] { CustomTheme } };
 
-            return new Theme(themeJson);
+            return new Theme(themeJson, errors);
         }
 
         //To Load the fluidGrid template defaults


### PR DESCRIPTION
Problem:
When the Themes.json file is changed to contain an empty string for the default script, it causes the program to crash without an error.

Solution:
Print out a new error that lets the user know there are empty strings for the default scripts in the Themes.json file.