### PR TITLE
Making YamlWriter a public class

### DIFF
--- a/src/PAModel/PAConvert/Yaml/YamlWriter.cs
+++ b/src/PAModel/PAConvert/Yaml/YamlWriter.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Text;
 
 namespace Microsoft.PowerPlatform.Formulas.Tools.Yaml
 {

--- a/src/PAModel/PAConvert/Yaml/YamlWriter.cs
+++ b/src/PAModel/PAConvert/Yaml/YamlWriter.cs
@@ -12,7 +12,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Yaml
     /// Notably, property values are always either multi-line escaped or
     /// prefixed with '=' to block yaml from treating it as a yaml expression.
     /// </summary>
-    internal class YamlWriter
+    public class YamlWriter
     {
         private readonly TextWriter _text;
         private int _currentIndent;

--- a/src/PAModel/PAConvert/Yaml/YamlWriter.cs
+++ b/src/PAModel/PAConvert/Yaml/YamlWriter.cs
@@ -47,11 +47,11 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Yaml
         }
 
         public void WriteProperty(string propertyName, bool value)
-        {            
+        {
             WriteIndent();
             _text.Write(propertyName);
             _text.Write(": ");
-            _text.WriteLine(value ? "true" : "false");            
+            _text.WriteLine(value ? "true" : "false");
         }
 
         public void WriteProperty(string propertyName, int value)
@@ -76,7 +76,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Yaml
         /// </summary>
         /// <param name="propertyName"></param>
         /// <param name="value"></param>
-        public void WriteProperty(string propertyName, string value, bool includeEquals=true)
+        public void WriteProperty(string propertyName, string value, bool includeEquals = true)
         {
             if (value == null)
             {
@@ -93,7 +93,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Yaml
             // For consistency, both single and multiline PA properties prefix with '='.
             // Only single-line actually needs this - to avoid yaml's regular expression escaping.
             if (includeEquals)
-            {                
+            {
                 value = '=' + value;
             }
 
@@ -173,7 +173,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Yaml
             }
         }
 
-        public static string NormalizeNewlines(string x)
+        private string NormalizeNewlines(string x)
         {
             return x.Replace("\r\n", "\n").Replace("\r", "\n");
         }

--- a/src/PAModelTests/PublicSurfaceTests.cs
+++ b/src/PAModelTests/PublicSurfaceTests.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.PowerPlatform.Formulas.Tools;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json.Serialization;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -28,13 +27,14 @@ namespace PAModelTests
                 $"{ns}.{nameof(Error)}",
                 $"Microsoft.PowerPlatform.YamlConverter",
                 $"Microsoft.PowerPlatform.YamlPocoSerializer",
+                $"Microsoft.PowerPlatform.Formulas.Tools.Yaml.YamlWriter",
 
                 // Public schemas
-                $"Microsoft.PowerPlatform.Formulas.Tools.Schemas.ParameterSchema"                
+                $"Microsoft.PowerPlatform.Formulas.Tools.Schemas.ParameterSchema"
             };
 
             StringBuilder sb = new StringBuilder();
-            foreach(var type in asm.GetTypes().Where(t => t.IsPublic))
+            foreach (var type in asm.GetTypes().Where(t => t.IsPublic))
             {
                 var name = type.FullName;
                 if (!allowed.Contains(name))
@@ -49,7 +49,7 @@ namespace PAModelTests
             Assert.AreEqual(0, sb.Length, $"Unexpected public types: {sb}");
 
             // Types we expect to be in the assembly aren't there. 
-            Assert.AreEqual(0, allowed.Count); 
+            Assert.AreEqual(0, allowed.Count);
         }
     }
 }


### PR DESCRIPTION
Making `YamlWriter` a public class so it can be utilized by other projects looking to conform to the Power App specific flavor of YAML.