### PR TITLE
Appended Call Stack to error message for Internal Error

### DIFF
--- a/src/PAModel/PAConvert/ErrorCode.cs
+++ b/src/PAModel/PAConvert/ErrorCode.cs
@@ -104,7 +104,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
         public static void InternalError(this ErrorContainer errors, Exception e)
         {
-            errors.AddError(ErrorCode.InternalError, default(SourceLocation), $"Internal error. {e.Message}");
+            errors.AddError(ErrorCode.InternalError, default(SourceLocation), $"Internal error. {e.Message}, \n{e.StackTrace}");
         }
 
         public static void UnsupportedOperationError(this ErrorContainer errors, string message)

--- a/src/PAModel/PAConvert/ErrorCode.cs
+++ b/src/PAModel/PAConvert/ErrorCode.cs
@@ -104,7 +104,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
         public static void InternalError(this ErrorContainer errors, Exception e)
         {
-            errors.AddError(ErrorCode.InternalError, default(SourceLocation), $"Internal error. {e.Message}, \n{e.StackTrace}");
+            errors.AddError(ErrorCode.InternalError, default(SourceLocation), $"Internal error. {e.Message}\nStack Trace:\n{e.StackTrace}");
         }
 
         public static void UnsupportedOperationError(this ErrorContainer errors, string message)

--- a/src/PAModel/PAConvert/ErrorCode.cs
+++ b/src/PAModel/PAConvert/ErrorCode.cs
@@ -104,7 +104,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
         public static void InternalError(this ErrorContainer errors, Exception e)
         {
-            errors.AddError(ErrorCode.InternalError, default(SourceLocation), $"Internal error. {e.Message}\nStack Trace:\n{e.StackTrace}");
+            errors.AddError(ErrorCode.InternalError, default(SourceLocation), $"Internal error. {e.Message}\r\nStack Trace:\r\n{e.StackTrace}");
         }
 
         public static void UnsupportedOperationError(this ErrorContainer errors, string message)


### PR DESCRIPTION
Appended the call stack to the error message when an internal error is thrown. This should now provide additional diagnostic information when such an error occurs.