### PR TITLE
Handling connection instance id and avoiding noisy diffs

### DIFF
--- a/src/PAModel/Entropy.cs
+++ b/src/PAModel/Entropy.cs
@@ -85,6 +85,9 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         /// </summary>
         public bool? WasLocalDatabaseReferencesEmpty { get; set; }
 
+        // Key is connection id, value is connection instance id
+        public Dictionary<string, string> LocalConnectionIDReferences { get; set; } = new Dictionary<string, string>(StringComparer.Ordinal);
+
         public int GetOrder(DataSourceEntry dataSource)
         {
             // To ensure that that TableDefinitions are put at the end in DataSources.json when the order information is not available.

--- a/src/PAModel/Serializers/MsAppSerializer.cs
+++ b/src/PAModel/Serializers/MsAppSerializer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
     // Read/Write to an .msapp file. 
     internal static class MsAppSerializer
     {
-        internal static readonly string ConnectionInstanceIDPropertyName = "connectionInstanceId";
+        public const string ConnectionInstanceIDPropertyName = "connectionInstanceId";
 
         private static T ToObject<T>(ZipArchiveEntry entry)
         {
@@ -566,8 +566,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                             connectionIDReferences.Remove(connection.Key);
                         }
                     }
-                    app._entropy.LocalConnectionIDReferences = null;
                 }
+
                 var json = Utilities.JsonSerialize(app._connections);
                 props.LocalConnectionReferences = json;
             }

--- a/src/PAModel/Serializers/MsAppSerializer.cs
+++ b/src/PAModel/Serializers/MsAppSerializer.cs
@@ -550,7 +550,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             if (app._connections != null)
             {
                 var connectionIDReferences = app._entropy.LocalConnectionIDReferences;
-                if (connectionIDReferences != null)
+                if (connectionIDReferences != null && connectionIDReferences.Count != 0)
                 {
                     foreach (var connection in app._connections)
                     {

--- a/src/PAModel/Serializers/MsAppSerializer.cs
+++ b/src/PAModel/Serializers/MsAppSerializer.cs
@@ -12,12 +12,15 @@ using System.IO.Compression;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using System.Text.Encodings;
 
 namespace Microsoft.PowerPlatform.Formulas.Tools
 {
     // Read/Write to an .msapp file. 
     internal static class MsAppSerializer
     {
+        internal static readonly string ConnectionInstanceIDPropertyName = "connectionInstanceId";
+
         private static T ToObject<T>(ZipArchiveEntry entry)
         {
             if (entry.Name.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase))
@@ -295,6 +298,25 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 if (!string.IsNullOrEmpty(app._properties.LocalConnectionReferences))
                 {
                     var cxs = Utilities.JsonParse<IDictionary<String, ConnectionJson>>(app._properties.LocalConnectionReferences);
+
+                    foreach (var connectionJson in cxs)
+                    {
+                        var extensionData = connectionJson.Value.ExtensionData;
+                        if (extensionData != null)
+                        {
+                            if (extensionData.TryGetValue(ConnectionInstanceIDPropertyName, out JsonElement connectionInstanceID))
+                            {
+                                var serializedID = JsonSerializer.Serialize(connectionInstanceID);
+
+                                // Mapping the connection key to the serializedID and adding it to _entropy                                
+                                app._entropy.LocalConnectionIDReferences.Add(connectionJson.Key, serializedID);
+
+                                // Basically making sure conn instance id is not added to app._connections
+                                extensionData.Remove(ConnectionInstanceIDPropertyName);
+                            }                              
+                        }
+                    }
+
                     app._connections = cxs;
                     app._properties.LocalConnectionReferences = null;
                 }
@@ -527,6 +549,25 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             var props = app._properties.JsonClone();
             if (app._connections != null)
             {
+                var connectionIDReferences = app._entropy.LocalConnectionIDReferences;
+                if (connectionIDReferences != null)
+                {
+                    foreach (var connection in app._connections)
+                    {
+                        if (connectionIDReferences.TryGetValue(connection.Key, out string instanceID))
+                        {
+                            var extensionData = connection.Value.ExtensionData;
+                            JsonElement connectionInstanceID = JsonSerializer.Deserialize<JsonElement>(instanceID);
+
+                            // Deserialized conn instance id is added to the extension data to eventually add it back to properties.json while packing
+                            extensionData.Add(ConnectionInstanceIDPropertyName, connectionInstanceID);
+
+                            // Making sure instance references are removed after adding it to the extension data
+                            connectionIDReferences.Remove(connection.Key);
+                        }
+                    }
+                    app._entropy.LocalConnectionIDReferences = null;
+                }
                 var json = Utilities.JsonSerialize(app._connections);
                 props.LocalConnectionReferences = json;
             }

--- a/src/PAModelTests/DataSourceTests.cs
+++ b/src/PAModelTests/DataSourceTests.cs
@@ -111,7 +111,7 @@ namespace PAModelTests
             using var sourcesTempDir = new TempDir();
             var sourcesTempDirPath = sourcesTempDir.Dir;
             ErrorContainer  errorsCaptured = msApp.SaveToSources(sourcesTempDirPath);
-            errors.ThrowOnErrors();
+            errorsCaptured.ThrowOnErrors();
 
             var loadedMsApp = SourceSerializer.LoadFromSource(sourcesTempDirPath, new ErrorContainer());
 

--- a/src/PAModelTests/DataSourceTests.cs
+++ b/src/PAModelTests/DataSourceTests.cs
@@ -108,15 +108,13 @@ namespace PAModelTests
             var (msApp, errors) = CanvasDocument.LoadFromMsapp(pathToMsApp);
             errors.ThrowOnErrors();
 
+            // Testing if conn instance id is added to entropy
+            Assert.IsNotNull(msApp._entropy.LocalConnectionIDReferences);
+
             using var sourcesTempDir = new TempDir();
             var sourcesTempDirPath = sourcesTempDir.Dir;
-            ErrorContainer  errorsCaptured = msApp.SaveToSources(sourcesTempDirPath);
-            errorsCaptured.ThrowOnErrors();
-
-            var loadedMsApp = SourceSerializer.LoadFromSource(sourcesTempDirPath, new ErrorContainer());
-
-            // Testing if conn instance id is added to entropy
-            Assert.IsNotNull(loadedMsApp._entropy.LocalConnectionIDReferences);
+            ErrorContainer  errorsCaptured = msApp.SaveToSources(sourcesTempDirPath, pathToMsApp);
+            errorsCaptured.ThrowOnErrors();            
         }
 
         private static T ToObject<T>(ZipArchiveEntry entry)

--- a/src/PAModelTests/DataSourceTests.cs
+++ b/src/PAModelTests/DataSourceTests.cs
@@ -110,23 +110,13 @@ namespace PAModelTests
 
             using var sourcesTempDir = new TempDir();
             var sourcesTempDirPath = sourcesTempDir.Dir;
-            msApp.SaveToSources(sourcesTempDirPath);
+            ErrorContainer  errorsCaptured = msApp.SaveToSources(sourcesTempDirPath);
+            errors.ThrowOnErrors();
 
             var loadedMsApp = SourceSerializer.LoadFromSource(sourcesTempDirPath, new ErrorContainer());
 
             // Testing if conn instance id is added to entropy
             Assert.IsNotNull(loadedMsApp._entropy.LocalConnectionIDReferences);
-
-            using (var tempFile = new TempFile())
-            {
-                // Repack the app
-                MsAppSerializer.SaveAsMsApp(loadedMsApp, tempFile.FullPath, new ErrorContainer());
-
-                // Comparing original .msapp with repacked .msapp
-                // and testing no deltas 
-                bool ok = MsAppTest.MergeStressTest(pathToMsApp, tempFile.FullPath);
-                Assert.IsTrue(ok);
-            }
         }
 
         private static T ToObject<T>(ZipArchiveEntry entry)


### PR DESCRIPTION
Problem : Noisy diffs because of connection instance ids

Solution:
- Extracting connection instance ids from connections.json to entropy.json from properties.json while unpacking
- Making sure to add it back to properties while repacking
