### PR TITLE
Updating package details in PALT repo build

### DIFF
--- a/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
+++ b/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
@@ -18,11 +18,11 @@
     <Description>Preview Release: This takes a Canvas App (.msapp file) and converts to and from text files that can be checked into source control.</Description>
     <PackageReleaseNotes>
         Notice:
-            This package is a preview release. - Use at your own risk.
+            This package is a preview release - use at your own risk.
             This package is a .NET Standard 2.0 project, intended to work with .NET Framework 4.7.2 or later, and .NET Core 2.2 or later
             We have not stabilized on Namespace or Class names with this package as of yet and things will change as we move though the preview.
 
-        See https://github.com/microsoft/PowerApps-Language-Tooling/releases for the latest release notes
+        See https://github.com/microsoft/PowerApps-Language-Tooling/releases for the latest release notes.
     </PackageReleaseNotes>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <SignAssembly>true</SignAssembly>

--- a/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
+++ b/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
@@ -17,28 +17,12 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Description>Preview Release: This takes a Canvas App (.msapp file) and converts to and from text files that can be checked into source control.</Description>
     <PackageReleaseNotes>
-        Notice: 
-            This package is a preview release. - Use at your own risk.
-            This package is a .NET Standard 2.0 project, intended to work with .NET Framework 4.7.2 or later, and .NET Core 2.2 or later
-            We have not stabilized on Namespace or Class names with this package as of yet and things will change as we move though the preview.
+        Notice:
+        This package is a preview release. - Use at your own risk.
+        This package is a .NET Standard 2.0 project, intended to work with .NET Framework 4.7.2 or later, and .NET Core 2.2 or later
+        We have not stabilized on Namespace or Class names with this package as of yet and things will change as we move though the preview.
 
-        0.3.0-preview
-            Improved error and exception handling, better file sharding, other bug fixes and improvements
-
-        0.2.0-preview
-            Changed file extension to .fx.yaml, other bug fixes and improvements
-
-        0.1.1-preview
-            Changed checksum implementation, bug fixes 
-
-        0.1.0-preview
-            Initial Preview Release
-
-        0.0.2-alpha
-            Updated control format to be YAML Compatible
-    
-        0.0.1-alpha
-            Intial Alpha release of Microsoft.PowerPlatform.Formulas.Tools
+        See https://github.com/microsoft/PowerApps-Language-Tooling/releases for the latest release notes.
     </PackageReleaseNotes>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <SignAssembly>true</SignAssembly>

--- a/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
+++ b/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
@@ -44,6 +44,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <PublicSign>true</PublicSign>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
+++ b/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
@@ -18,11 +18,11 @@
     <Description>Preview Release: This takes a Canvas App (.msapp file) and converts to and from text files that can be checked into source control.</Description>
     <PackageReleaseNotes>
         Notice:
-        This package is a preview release. - Use at your own risk.
-        This package is a .NET Standard 2.0 project, intended to work with .NET Framework 4.7.2 or later, and .NET Core 2.2 or later
-        We have not stabilized on Namespace or Class names with this package as of yet and things will change as we move though the preview.
+            This package is a preview release. - Use at your own risk.
+            This package is a .NET Standard 2.0 project, intended to work with .NET Framework 4.7.2 or later, and .NET Core 2.2 or later
+            We have not stabilized on Namespace or Class names with this package as of yet and things will change as we move though the preview.
 
-        See https://github.com/microsoft/PowerApps-Language-Tooling/releases for the latest release notes.
+        See https://github.com/microsoft/PowerApps-Language-Tooling/releases for the latest release notes
     </PackageReleaseNotes>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
- Setting GenerateAssemblyInfo property true for PALT package in .csproj results in details including assembly version linked to the build.
- Also updating the release note