### PR TITLE
Fixing exception from not handling special characters on canvas unpack

### DIFF
--- a/src/PAModel/Utility/FilePath.cs
+++ b/src/PAModel/Utility/FilePath.cs
@@ -109,7 +109,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Utility
         {
             if (_pathSegments.Length == 0)
                 return string.Empty;
-            return Path.GetExtension(_pathSegments.Last());
+            return Path.GetExtension(Utilities.EscapeFilename(_pathSegments.Last()));
         }
 
         public override bool Equals(object obj)

--- a/src/PAModelTests/DataSourceTests.cs
+++ b/src/PAModelTests/DataSourceTests.cs
@@ -120,6 +120,7 @@ namespace PAModelTests
         [DataTestMethod]
         [DataRow(new string[] {"FileNameOne.txt" }, ".txt")]
         [DataRow(new string[] {"FileNameTwo.tx<t" }, ".tx%3ct")]
+        [DataRow(new string[] { "FileNameThr<ee.txt" }, ".txt")]
         public void TestGetExtensionEncoded(string[] fileExtension, string encodedExtension)
         {
             FilePath filePath = new FilePath(fileExtension);

--- a/src/PAModelTests/DataSourceTests.cs
+++ b/src/PAModelTests/DataSourceTests.cs
@@ -117,6 +117,25 @@ namespace PAModelTests
             errorsCaptured.ThrowOnErrors();            
         }
 
+        [DataTestMethod]
+        [DataRow("NameOne")]
+        [DataRow("NameTwo>")]
+        [DataRow("NameThree><*/")]
+        public void TestGetExtensionEncoded(string fileString)
+        {
+            // Make sure exception is not thrown
+            try
+            {
+                FilePath filePath = new FilePath(fileString);
+                filePath.GetExtension();
+            }
+            // If it is thrown, Fail test
+            catch (System.ArgumentException)
+            {
+                Assert.Fail();
+            }
+        }
+
         private static T ToObject<T>(ZipArchiveEntry entry)
         {
             var je = entry.ToJson();

--- a/src/PAModelTests/DataSourceTests.cs
+++ b/src/PAModelTests/DataSourceTests.cs
@@ -104,7 +104,7 @@ namespace PAModelTests
         {
             var pathToMsApp = Path.Combine(Environment.CurrentDirectory, "Apps", appName);
             Assert.IsTrue(File.Exists(pathToMsApp));
-            
+
             var (msApp, errors) = CanvasDocument.LoadFromMsapp(pathToMsApp);
             errors.ThrowOnErrors();
 
@@ -113,27 +113,17 @@ namespace PAModelTests
 
             using var sourcesTempDir = new TempDir();
             var sourcesTempDirPath = sourcesTempDir.Dir;
-            ErrorContainer  errorsCaptured = msApp.SaveToSources(sourcesTempDirPath, pathToMsApp);
-            errorsCaptured.ThrowOnErrors();            
+            ErrorContainer errorsCaptured = msApp.SaveToSources(sourcesTempDirPath, pathToMsApp);
+            errorsCaptured.ThrowOnErrors();
         }
 
         [DataTestMethod]
-        [DataRow("NameOne")]
-        [DataRow("NameTwo>")]
-        [DataRow("NameThree><*/")]
-        public void TestGetExtensionEncoded(string fileString)
+        [DataRow(new string[] {"FileNameOne.txt" }, ".txt")]
+        [DataRow(new string[] {"FileNameTwo.tx<t" }, ".tx%3ct")]
+        public void TestGetExtensionEncoded(string[] fileExtension, string encodedExtension)
         {
-            // Make sure exception is not thrown
-            try
-            {
-                FilePath filePath = new FilePath(fileString);
-                filePath.GetExtension();
-            }
-            // If it is thrown, Fail test
-            catch (System.ArgumentException)
-            {
-                Assert.Fail();
-            }
+            FilePath filePath = new FilePath(fileExtension);
+            Assert.AreEqual(filePath.GetExtension(), encodedExtension);
         }
 
         private static T ToObject<T>(ZipArchiveEntry entry)


### PR DESCRIPTION
Problem:
An exception is thrown when special characters are present in the filepath, during canvas unpack.

Solution:
When getting the filepath, escape out special characters.