### PR TITLE
Additional Roundtrip Logging in Release & Remove Double Roundtrip Printing

### DIFF
--- a/src/PAModel/Serializers/MsAppSerializer.cs
+++ b/src/PAModel/Serializers/MsAppSerializer.cs
@@ -504,14 +504,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
 #endif
 
-#if !DEBUG
-                // These are the non-debug warnings, if it's unpack this was a serious error, on -pack it's most likely not
-                if (isValidation)
-                {
-                    errors.PostUnpackValidationFailed();
-                    throw new DocumentException();
-                }
-#endif
                 errors.ChecksumMismatch("Checksum indicates that sources have been edited since they were unpacked. If this was intentional, ignore this warning.");
             }
 


### PR DESCRIPTION
Solution: Remove roundtrip error code in #if !DEBUG tags, which adds an extra roundtrip error in Release mode.