### PR TITLE
PA3005: "Group control x state refers to non-existent child"

### DIFF
--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -141,7 +141,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
                 if (child.Properties.Count > 3)
                 {
                     _errors.ValidationError($"Test Step {propName} has unexpected properties");
-                    throw new DocumentException();
                 }
                 var descriptionProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Description");
                 if (descriptionProp == null)

--- a/src/PAModel/SourceTransforms/ComponentInstanceTransform.cs
+++ b/src/PAModel/SourceTransforms/ComponentInstanceTransform.cs
@@ -37,12 +37,14 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
         private void DoRename(BlockNode control)
         {
             var templateName = control.Name?.Kind?.TypeName ?? string.Empty;
-            if (!ComponentRenames.TryGetValue(templateName, out var rename))
+            if (ComponentRenames.TryGetValue(templateName, out var rename))
+            {
+                control.Name.Kind.TypeName = rename;
+            }
+            else
             {
                 _errors.ValidationError("Renaming component instance but unable to find target name");
-                throw new DocumentException();
             }
-            control.Name.Kind.TypeName = rename;
         }
     }
 }

--- a/src/PAModel/SourceTransforms/GroupControlTransform.cs
+++ b/src/PAModel/SourceTransforms/GroupControlTransform.cs
@@ -55,12 +55,15 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
 
                 foreach (var childKey in groupControlState.GroupedControlsKey)
                 {
-                    if (!peerControlsDict.TryGetValue(childKey, out var newChild))
+                    if (peerControlsDict.TryGetValue(childKey, out var newChild))
+                    {
+                        groupControl.Children.Add(newChild);
+                        peerControlsDict.Remove(childKey);
+                    }
+                    else
                     {
                         _errors.ValidationError($"Group control {groupControlName}'s state refers to non-existent child {childKey}");
                     }
-                    groupControl.Children.Add(newChild);
-                    peerControlsDict.Remove(childKey);
                 }
                 groupControlState.GroupedControlsKey = null;
             }

--- a/src/PAModel/SourceTransforms/GroupControlTransform.cs
+++ b/src/PAModel/SourceTransforms/GroupControlTransform.cs
@@ -58,7 +58,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
                     if (!peerControlsDict.TryGetValue(childKey, out var newChild))
                     {
                         _errors.ValidationError($"Group control {groupControlName}'s state refers to non-existent child {childKey}");
-                        throw new DocumentException();
                     }
                     groupControl.Children.Add(newChild);
                     peerControlsDict.Remove(childKey);


### PR DESCRIPTION
Top errors are showing multiple results that seem like it is detecting a runtime error. This should not prevent pack\unpack from completing successfully. Should also evaluate other PA3005 to determine if there are other scenarios like this one which we can avoid.

Solution:
Remove exception throw for relevant errors.