### PR TITLE
Empty TestStepsMetadata rule causing hash mismatch

### DIFF
--- a/src/PAModel/Entropy.cs
+++ b/src/PAModel/Entropy.cs
@@ -85,6 +85,11 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         /// </summary>
         public bool? WasLocalDatabaseReferencesEmpty { get; set; }
 
+        /// <summary>
+        /// Tracks whether TestStepsMetadata is empty or not.
+        /// </summary>
+        public bool? TestStepsMetadataEmpty { get; set; }
+
         // Key is connection id, value is connection instance id
         public Dictionary<string, string> LocalConnectionIDReferences { get; set; } = new Dictionary<string, string>(StringComparer.Ordinal);
 

--- a/src/PAModel/Entropy.cs
+++ b/src/PAModel/Entropy.cs
@@ -88,7 +88,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         /// <summary>
         /// Tracks whether TestStepsMetadata is empty or not.
         /// </summary>
-        public bool? DoesTestStepsMetadataExist = true;
+        public bool? DoesTestStepsMetadataExist { get; set; }
 
         // Key is connection id, value is connection instance id
         public Dictionary<string, string> LocalConnectionIDReferences { get; set; } = new Dictionary<string, string>(StringComparer.Ordinal);

--- a/src/PAModel/Entropy.cs
+++ b/src/PAModel/Entropy.cs
@@ -88,7 +88,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         /// <summary>
         /// Tracks whether TestStepsMetadata is empty or not.
         /// </summary>
-        public bool DoesTestStepsMetadataExist { get; set; }
+        public bool? DoesTestStepsMetadataExist { get; set; }
 
         // Key is connection id, value is connection instance id
         public Dictionary<string, string> LocalConnectionIDReferences { get; set; } = new Dictionary<string, string>(StringComparer.Ordinal);

--- a/src/PAModel/Entropy.cs
+++ b/src/PAModel/Entropy.cs
@@ -88,7 +88,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         /// <summary>
         /// Tracks whether TestStepsMetadata is empty or not.
         /// </summary>
-        public bool? TestStepsMetadataEmpty { get; set; }
+        public bool DoesTestStepsMetadataExist { get; set; }
 
         // Key is connection id, value is connection instance id
         public Dictionary<string, string> LocalConnectionIDReferences { get; set; } = new Dictionary<string, string>(StringComparer.Ordinal);

--- a/src/PAModel/Entropy.cs
+++ b/src/PAModel/Entropy.cs
@@ -88,7 +88,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         /// <summary>
         /// Tracks whether TestStepsMetadata is empty or not.
         /// </summary>
-        public bool? DoesTestStepsMetadataExist { get; set; }
+        public bool? DoesTestStepsMetadataExist = true;
 
         // Key is connection id, value is connection instance id
         public Dictionary<string, string> LocalConnectionIDReferences { get; set; } = new Dictionary<string, string>(StringComparer.Ordinal);

--- a/src/PAModel/IR/IRStateHelpers.cs
+++ b/src/PAModel/IR/IRStateHelpers.cs
@@ -486,9 +486,14 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 property.NameMap = propState.NameMap;
                 property.RuleProviderType = propState.RuleProviderType;
             }
-            else
+            else if (state.IsComponentDefinition ?? false)
             {
-                errors.UnsupportedOperationError("This tool currently does not support adding new custom properties to components. Please use Power Apps Studio to edit component definitions");
+                    errors.UnsupportedOperationError("This tool currently does not support adding new custom properties to components. Please use Power Apps Studio to edit component definitions");
+                    throw new DocumentException();
+            }
+            else 
+            {
+                errors.UnsupportedOperationError("You cannot add an empty property.");
                 throw new DocumentException();
             }
 

--- a/src/PAModel/IR/IRStateHelpers.cs
+++ b/src/PAModel/IR/IRStateHelpers.cs
@@ -308,17 +308,15 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                         RepopulateTemplateCustomProperties(func, templateState, errors, entropy);
                     }
                 }
-                else if (template.CustomProperties?.Any(prop => prop.IsFunctionProperty) ?? false)
+                else 
                 {
-                    // For component uses, recreate the dummy props for function parameters
-                    foreach (var hiddenScopeRule in template.CustomProperties.Where(prop => prop.IsFunctionProperty).SelectMany(prop => prop.PropertyScopeKey.PropertyScopeRulesKey))
+                    if (state.IsComponentDefinition ?? false)
                     {
-                        if (!properties.Any(x => x.Property == hiddenScopeRule.Name))
-                        {
-                            var script = entropy.GetInvariantScript(hiddenScopeRule.Name, hiddenScopeRule.ScopeVariableInfo.DefaultRule);
-                            properties.Add(GetPropertyEntry(state, errors, hiddenScopeRule.Name, script));
-                        }
+                        errors.UnsupportedOperationError("This tool currently does not support adding new custom properties to components. Please use Power Apps Studio to edit component definitions");
+                        throw new DocumentException();
                     }
+
+                    property.RuleProviderType = "Unknown";
                 }
 
                 // Preserve ordering from serialized IR

--- a/src/PAModel/IR/IRStateHelpers.cs
+++ b/src/PAModel/IR/IRStateHelpers.cs
@@ -486,7 +486,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 property.NameMap = propState.NameMap;
                 property.RuleProviderType = propState.RuleProviderType;
             }
-            else 
+            else
             {
                 if (state.IsComponentDefinition ?? false)
                 {

--- a/src/PAModel/IR/IRStateHelpers.cs
+++ b/src/PAModel/IR/IRStateHelpers.cs
@@ -488,13 +488,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             }
             else
             {
-                if (state.IsComponentDefinition ?? false)
-                {
-                    errors.UnsupportedOperationError("This tool currently does not support adding new custom properties to components. Please use Power Apps Studio to edit component definitions");
-                    throw new DocumentException();
-                }
-
-                property.RuleProviderType = "Unknown";
+                errors.UnsupportedOperationError("This tool currently does not support adding new custom properties to components. Please use Power Apps Studio to edit component definitions");
+                throw new DocumentException();
             }
 
             return property;

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -139,7 +139,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
         public void BeforeWrite(BlockNode control)
         {
             var testStepsMetadata = new List<TestStepsMetadataJson>();
-            
+
             foreach (var child in control.Children)
             {
                 var propName = child.Name.Identifier;
@@ -182,7 +182,12 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
                     throw new DocumentException();
                 }
                 
-
+                // If TestStepsMetadata exists, add
+                if (_entropy.DoesTestStepsMetadataExist == null)
+                {
+                    _entropy.DoesTestStepsMetadataExist = true;
+                }
+                
                 if (_entropy.DoesTestStepsMetadataExist == true)
                 {
 
@@ -202,6 +207,12 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
                 }
             }
 
+            // If TestStepsMetadata exists, add
+            if (_entropy.DoesTestStepsMetadataExist == null)
+            {
+                 _entropy.DoesTestStepsMetadataExist = true;
+            }
+            
             if (_entropy.DoesTestStepsMetadataExist == true)
             {
                 var testStepMetadataStr = JsonSerializer.Serialize<List<TestStepsMetadataJson>>(testStepsMetadata, new JsonSerializerOptions() {Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping });

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -140,56 +140,58 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
         {
             var testStepsMetadata = new List<TestStepsMetadataJson>();
 
-            // If no TestStepsMetadata were added in AfterRead, do not add
-            if (_entropy.TestStepsMetadataEmpty == false)
+            // If no TestStepsMetadata were added in AfterRead, exit
+            if (_entropy.TestStepsMetadataEmpty == true)
             {
-                foreach (var child in control.Children)
+                return;
+            }
+
+            foreach (var child in control.Children)
+            {
+                var propName = child.Name.Identifier;
+                if (child.Name.Kind.TypeName != _testStepTemplateName)
                 {
-                    var propName = child.Name.Identifier;
-                    if (child.Name.Kind.TypeName != _testStepTemplateName)
-                    {
-                        _errors.ValidationError($"Only controls of type {_testStepTemplateName} are valid children of a TestCase");
-                        throw new DocumentException();
-                    }
-                    if (child.Properties.Count > 3)
-                    {
-                        _errors.ValidationError($"Test Step {propName} has unexpected properties");
-                    }
-                    var descriptionProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Description");
-                    if (descriptionProp == null)
-                    {
-                        _errors.ValidationError($"Test Step {propName} is missing a Description property");
-                        throw new DocumentException();
-                    }
-                    var valueProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Value");
-                    if (valueProp == null)
-                    {
-                        _errors.ValidationError($"Test Step {propName} is missing a Value property");
-                        throw new DocumentException();
-                    }
-                    var screenProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Screen");
-
-                    string screenId = null;
-                    // Lookup screenID by Name
-                    if (screenProp != null && !_screenIdToScreenName.ToDictionary(kvp => kvp.Value, kvp => kvp.Key).TryGetValue(screenProp.Expression.Expression, out screenId))
-                    {
-                        _errors.ValidationError($"Test Step {propName} references screen {screenProp.Expression.Expression} that is not present in the app");
-                        throw new DocumentException();
-                    }
-
-                    testStepsMetadata.Add(new TestStepsMetadataJson()
-                    {
-                        Description = Utilities.UnEscapePAString(descriptionProp.Expression.Expression),
-                        Rule = propName,
-                        ScreenId = screenId
-                    });
-
-                    control.Properties.Add(new PropertyNode()
-                    {
-                        Expression = valueProp.Expression,
-                        Identifier = propName
-                    });
+                    _errors.ValidationError($"Only controls of type {_testStepTemplateName} are valid children of a TestCase");
+                    throw new DocumentException();
                 }
+                if (child.Properties.Count > 3)
+                {
+                    _errors.ValidationError($"Test Step {propName} has unexpected properties");
+                }
+                var descriptionProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Description");
+                if (descriptionProp == null)
+                {
+                    _errors.ValidationError($"Test Step {propName} is missing a Description property");
+                    throw new DocumentException();
+                }
+                var valueProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Value");
+                if (valueProp == null)
+                {
+                    _errors.ValidationError($"Test Step {propName} is missing a Value property");
+                    throw new DocumentException();
+                }
+                var screenProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Screen");
+
+                string screenId = null;
+                // Lookup screenID by Name
+                if (screenProp != null && !_screenIdToScreenName.ToDictionary(kvp => kvp.Value, kvp => kvp.Key).TryGetValue(screenProp.Expression.Expression, out screenId))
+                {
+                    _errors.ValidationError($"Test Step {propName} references screen {screenProp.Expression.Expression} that is not present in the app");
+                    throw new DocumentException();
+                }
+
+                testStepsMetadata.Add(new TestStepsMetadataJson()
+                {
+                    Description = Utilities.UnEscapePAString(descriptionProp.Expression.Expression),
+                    Rule = propName,
+                    ScreenId = screenId
+                });
+
+                control.Properties.Add(new PropertyNode()
+                {
+                    Expression = valueProp.Expression,
+                    Identifier = propName
+                });
             }
             var testStepMetadataStr = JsonSerializer.Serialize<List<TestStepsMetadataJson>>(testStepsMetadata, new JsonSerializerOptions() {Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
             control.Properties.Add(new PropertyNode()

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -183,7 +183,11 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
                 }
                 
                 // If TestStepsMetadata exists, add
-                if (_entropy.DoesTestStepsMetadataExist)
+                if (_entropy.DoesTestStepsMetadataExist == null)
+                {
+                    _errors.ValidationError($"Cannot verify if TestStepMetadata exists or not.");
+                }
+                else if (_entropy.DoesTestStepsMetadataExist == true)
                 {
 
                     testStepsMetadata.Add(new TestStepsMetadataJson()
@@ -203,9 +207,12 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
             }
 
             // If TestStepsMetadata exists, add
-            if (_entropy.DoesTestStepsMetadataExist)
+            if (_entropy.DoesTestStepsMetadataExist == null)
             {
-
+                _errors.ValidationError($"Cannot verify if TestStepMetadata exists or not.");
+            }
+            else if (_entropy.DoesTestStepsMetadataExist == true)
+            {
                 var testStepMetadataStr = JsonSerializer.Serialize<List<TestStepsMetadataJson>>(testStepsMetadata, new JsonSerializerOptions() {Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
                 control.Properties.Add(new PropertyNode()
                 {

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -139,13 +139,13 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
 
         public void BeforeWrite(BlockNode control)
         {
-            var testStepsMetadata = new List<TestStepsMetadataJson>();
-
             // If TestStepsMetadata does not exist, return early
             if (!_entropy.DoesTestStepsMetadataExist)
             {
                 return;
             }
+
+            var testStepsMetadata = new List<TestStepsMetadataJson>();
 
             foreach (var child in control.Children)
             {

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -140,60 +140,58 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
         {
             var testStepsMetadata = new List<TestStepsMetadataJson>();
 
-            // If there weren't TestStepsMetadata in AfterRead, exit
-            if (_entropy.TestStepsMetadataEmpty == true)
-            {
+            if(entropy.TestStepsMetadataEmpty == true){
                 return;
             }
-        
-            foreach (var child in control.Children)
-            {
-                var propName = child.Name.Identifier;
-                if (child.Name.Kind.TypeName != _testStepTemplateName)
-                {
-                    _errors.ValidationError($"Only controls of type {_testStepTemplateName} are valid children of a TestCase");
-                    throw new DocumentException();
-                }
-                if (child.Properties.Count > 3)
-                {
-                    _errors.ValidationError($"Test Step {propName} has unexpected properties");
-                }
-                var descriptionProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Description");
-                if (descriptionProp == null)
-                {
-                    _errors.ValidationError($"Test Step {propName} is missing a Description property");
-                    throw new DocumentException();
-                }
-                var valueProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Value");
-                if (valueProp == null)
-                {
-                    _errors.ValidationError($"Test Step {propName} is missing a Value property");
-                    throw new DocumentException();
-                }
-                var screenProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Screen");
 
-                string screenId = null;
-                // Lookup screenID by Name
-                if (screenProp != null && !_screenIdToScreenName.ToDictionary(kvp => kvp.Value, kvp => kvp.Key).TryGetValue(screenProp.Expression.Expression, out screenId))
+                foreach (var child in control.Children)
                 {
-                    _errors.ValidationError($"Test Step {propName} references screen {screenProp.Expression.Expression} that is not present in the app");
-                    throw new DocumentException();
+                    var propName = child.Name.Identifier;
+                    if (child.Name.Kind.TypeName != _testStepTemplateName)
+                    {
+                        _errors.ValidationError($"Only controls of type {_testStepTemplateName} are valid children of a TestCase");
+                        throw new DocumentException();
+                    }
+                    if (child.Properties.Count > 3)
+                    {
+                        _errors.ValidationError($"Test Step {propName} has unexpected properties");
+                    }
+                    var descriptionProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Description");
+                    if (descriptionProp == null)
+                    {
+                        _errors.ValidationError($"Test Step {propName} is missing a Description property");
+                        throw new DocumentException();
+                    }
+                    var valueProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Value");
+                    if (valueProp == null)
+                    {
+                        _errors.ValidationError($"Test Step {propName} is missing a Value property");
+                        throw new DocumentException();
+                    }
+                    var screenProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Screen");
+
+                    string screenId = null;
+                    // Lookup screenID by Name
+                    if (screenProp != null && !_screenIdToScreenName.ToDictionary(kvp => kvp.Value, kvp => kvp.Key).TryGetValue(screenProp.Expression.Expression, out screenId))
+                    {
+                        _errors.ValidationError($"Test Step {propName} references screen {screenProp.Expression.Expression} that is not present in the app");
+                        throw new DocumentException();
+                    }
+
+                    testStepsMetadata.Add(new TestStepsMetadataJson()
+                    {
+                        Description = Utilities.UnEscapePAString(descriptionProp.Expression.Expression),
+                        Rule = propName,
+                        ScreenId = screenId
+                    });
+
+                    control.Properties.Add(new PropertyNode()
+                    {
+                        Expression = valueProp.Expression,
+                        Identifier = propName
+                    });
                 }
 
-                testStepsMetadata.Add(new TestStepsMetadataJson()
-                {
-                    Description = Utilities.UnEscapePAString(descriptionProp.Expression.Expression),
-                    Rule = propName,
-                    ScreenId = screenId
-                });
-
-                control.Properties.Add(new PropertyNode()
-                {
-                    Expression = valueProp.Expression,
-                    Identifier = propName
-                });
-            }
-        
             var testStepMetadataStr = JsonSerializer.Serialize<List<TestStepsMetadataJson>>(testStepsMetadata, new JsonSerializerOptions() {Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
             control.Properties.Add(new PropertyNode()
             {

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -136,9 +136,14 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
             control.Children = newChildren;
         }
 
-       public void BeforeWrite(BlockNode control)
+        public void BeforeWrite(BlockNode control)
         {
             var testStepsMetadata = new List<TestStepsMetadataJson>();
+
+            // If no TestStepsMetadata were added in AfterRead, exit
+            if(_entropy.TestStepsMetadataEmpty == true){
+                return;
+            }
 
             foreach (var child in control.Children)
             {

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -202,17 +202,21 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
                 }
             }
 
-
-
-            var testStepMetadataStr = JsonSerializer.Serialize<List<TestStepsMetadataJson>>(testStepsMetadata, new JsonSerializerOptions() {Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
-            control.Properties.Add(new PropertyNode()
+            // If TestStepsMetadata exists, add
+            if (_entropy.DoesTestStepsMetadataExist)
             {
-                Expression = new ExpressionNode() { Expression = Utilities.EscapePAString(testStepMetadataStr) },
-                Identifier = _metadataPropName
-            });
+
+                var testStepMetadataStr = JsonSerializer.Serialize<List<TestStepsMetadataJson>>(testStepsMetadata, new JsonSerializerOptions() {Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
+                control.Properties.Add(new PropertyNode()
+                {
+                    Expression = new ExpressionNode() { Expression = Utilities.EscapePAString(testStepMetadataStr) },
+                    Identifier = _metadataPropName
+                });
 
 
-            control.Children = new List<BlockNode>();
+                control.Children = new List<BlockNode>();
+
+            }
         }
     }
 }

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -182,20 +182,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
                     throw new DocumentException();
                 }
                 
-                // If TestStepsMetadata exists, add
-                if (_entropy.DoesTestStepsMetadataExist == null)
-                {
-                    var properties = control.Properties.ToDictionary(prop => prop.Identifier);
-                    if (!properties.TryGetValue(_metadataPropName, out var metadataProperty))
-                    {
-                        // If no metadata props, TestStepsMetadata nonexistent
-                        _entropy.DoesTestStepsMetadataExist = false;
-                    }
-                    else{
-                        _entropy.DoesTestStepsMetadataExist = true;
-                    }
-                }
-                else if (_entropy.DoesTestStepsMetadataExist == true)
+
+                if (_entropy.DoesTestStepsMetadataExist == true)
                 {
 
                     testStepsMetadata.Add(new TestStepsMetadataJson()
@@ -214,20 +202,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
                 }
             }
 
-            // If TestStepsMetadata exists, add
-            if (_entropy.DoesTestStepsMetadataExist == null)
-            {
-                var properties = control.Properties.ToDictionary(prop => prop.Identifier);
-                if (!properties.TryGetValue(_metadataPropName, out var metadataProperty))
-                {
-                    // If no metadata props, TestStepsMetadata nonexistent
-                    _entropy.DoesTestStepsMetadataExist = false;
-                }
-                else{
-                    _entropy.DoesTestStepsMetadataExist = true;
-                }
-            }
-            else if (_entropy.DoesTestStepsMetadataExist == true)
+            if (_entropy.DoesTestStepsMetadataExist == true)
             {
                 var testStepMetadataStr = JsonSerializer.Serialize<List<TestStepsMetadataJson>>(testStepsMetadata, new JsonSerializerOptions() {Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
                 control.Properties.Add(new PropertyNode()

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -139,7 +139,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
         public void BeforeWrite(BlockNode control)
         {
             var testStepsMetadata = new List<TestStepsMetadataJson>();
-
+            
             foreach (var child in control.Children)
             {
                 var propName = child.Name.Identifier;
@@ -185,7 +185,15 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
                 // If TestStepsMetadata exists, add
                 if (_entropy.DoesTestStepsMetadataExist == null)
                 {
-                    _errors.ValidationError($"Cannot verify if TestStepMetadata exists or not.");
+                    var properties = control.Properties.ToDictionary(prop => prop.Identifier);
+                    if (!properties.TryGetValue(_metadataPropName, out var metadataProperty))
+                    {
+                        // If no metadata props, TestStepsMetadata nonexistent
+                        _entropy.DoesTestStepsMetadataExist = false;
+                    }
+                    else{
+                        _entropy.DoesTestStepsMetadataExist = true;
+                    }
                 }
                 else if (_entropy.DoesTestStepsMetadataExist == true)
                 {
@@ -209,7 +217,15 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
             // If TestStepsMetadata exists, add
             if (_entropy.DoesTestStepsMetadataExist == null)
             {
-                _errors.ValidationError($"Cannot verify if TestStepMetadata exists or not.");
+                var properties = control.Properties.ToDictionary(prop => prop.Identifier);
+                if (!properties.TryGetValue(_metadataPropName, out var metadataProperty))
+                {
+                    // If no metadata props, TestStepsMetadata nonexistent
+                    _entropy.DoesTestStepsMetadataExist = false;
+                }
+                else{
+                    _entropy.DoesTestStepsMetadataExist = true;
+                }
             }
             else if (_entropy.DoesTestStepsMetadataExist == true)
             {

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -78,7 +78,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
 
             foreach (var testStep in testStepsMetadata)
             {
-
                 if (!properties.TryGetValue(testStep.Rule, out var testStepProp))
                 {
                     _errors.ValidationError($"Unable to find corresponding property for test step {testStep.Rule} in {control.Name.Identifier}");

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -143,61 +143,74 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
             foreach (var child in control.Children)
             {
                 var propName = child.Name.Identifier;
+                
                 if (child.Name.Kind.TypeName != _testStepTemplateName)
                 {
                     _errors.ValidationError($"Only controls of type {_testStepTemplateName} are valid children of a TestCase");
                     throw new DocumentException();
                 }
+                
                 if (child.Properties.Count > 3)
                 {
                     _errors.ValidationError($"Test Step {propName} has unexpected properties");
                 }
+
                 var descriptionProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Description");
+                
                 if (descriptionProp == null)
                 {
                     _errors.ValidationError($"Test Step {propName} is missing a Description property");
                     throw new DocumentException();
                 }
+                
                 var valueProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Value");
+                
                 if (valueProp == null)
                 {
                     _errors.ValidationError($"Test Step {propName} is missing a Value property");
                     throw new DocumentException();
                 }
+                
                 var screenProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Screen");
 
                 string screenId = null;
+                
                 // Lookup screenID by Name
                 if (screenProp != null && !_screenIdToScreenName.ToDictionary(kvp => kvp.Value, kvp => kvp.Key).TryGetValue(screenProp.Expression.Expression, out screenId))
                 {
                     _errors.ValidationError($"Test Step {propName} references screen {screenProp.Expression.Expression} that is not present in the app");
                     throw new DocumentException();
                 }
-
-                testStepsMetadata.Add(new TestStepsMetadataJson()
+                
+                // If TestStepsMetadata exists, add
+                if (_entropy.DoesTestStepsMetadataExist)
                 {
-                    Description = Utilities.UnEscapePAString(descriptionProp.Expression.Expression),
-                    Rule = propName,
-                    ScreenId = screenId
-                });
 
-                control.Properties.Add(new PropertyNode()
-                {
-                    Expression = valueProp.Expression,
-                    Identifier = propName
-                });
+                    testStepsMetadata.Add(new TestStepsMetadataJson()
+                    {
+                        Description = Utilities.UnEscapePAString(descriptionProp.Expression.Expression),
+                        Rule = propName,
+                        ScreenId = screenId
+                    });
+
+                    control.Properties.Add(new PropertyNode()
+                    {
+                        Expression = valueProp.Expression,
+                        Identifier = propName
+                    });
+
+                }
             }
 
-            // If TestStepsMetadata does not exist, return early
-            if (_entropy.DoesTestStepsMetadataExist)
-            {            
-                var testStepMetadataStr = JsonSerializer.Serialize<List<TestStepsMetadataJson>>(testStepsMetadata, new JsonSerializerOptions() {Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
-                control.Properties.Add(new PropertyNode()
-                {
-                    Expression = new ExpressionNode() { Expression = Utilities.EscapePAString(testStepMetadataStr) },
-                    Identifier = _metadataPropName
-                });
-            }
+
+
+            var testStepMetadataStr = JsonSerializer.Serialize<List<TestStepsMetadataJson>>(testStepsMetadata, new JsonSerializerOptions() {Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
+            control.Properties.Add(new PropertyNode()
+            {
+                Expression = new ExpressionNode() { Expression = Utilities.EscapePAString(testStepMetadataStr) },
+                Identifier = _metadataPropName
+            });
+
 
             control.Children = new List<BlockNode>();
         }

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -187,19 +187,18 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
                     Identifier = propName
                 });
             }
-            
+
             // If TestStepsMetadata does not exist, return early
-            if (!_entropy.DoesTestStepsMetadataExist)
-            {
-                return;
+            if (_entropy.DoesTestStepsMetadataExist)
+            {            
+                var testStepMetadataStr = JsonSerializer.Serialize<List<TestStepsMetadataJson>>(testStepsMetadata, new JsonSerializerOptions() {Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
+                control.Properties.Add(new PropertyNode()
+                {
+                    Expression = new ExpressionNode() { Expression = Utilities.EscapePAString(testStepMetadataStr) },
+                    Identifier = _metadataPropName
+                });
             }
 
-            var testStepMetadataStr = JsonSerializer.Serialize<List<TestStepsMetadataJson>>(testStepsMetadata, new JsonSerializerOptions() {Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
-            control.Properties.Add(new PropertyNode()
-            {
-                Expression = new ExpressionNode() { Expression = Utilities.EscapePAString(testStepMetadataStr) },
-                Identifier = _metadataPropName
-            });
             control.Children = new List<BlockNode>();
         }
     }

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -139,6 +139,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
         public void BeforeWrite(BlockNode control)
         {
             var testStepsMetadata = new List<TestStepsMetadataJson>();
+            bool doesTestStepsMetadataExist = _entropy.DoesTestStepsMetadataExist ?? true;
 
             foreach (var child in control.Children)
             {
@@ -182,13 +183,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
                     throw new DocumentException();
                 }
                 
-                // If TestStepsMetadata exists, add
-                if (_entropy.DoesTestStepsMetadataExist == null)
-                {
-                    _entropy.DoesTestStepsMetadataExist = true;
-                }
-                
-                if (_entropy.DoesTestStepsMetadataExist == true)
+
+                if (doesTestStepsMetadataExist)
                 {
 
                     testStepsMetadata.Add(new TestStepsMetadataJson()
@@ -206,14 +202,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
 
                 }
             }
-
-            // If TestStepsMetadata exists, add
-            if (_entropy.DoesTestStepsMetadataExist == null)
-            {
-                 _entropy.DoesTestStepsMetadataExist = true;
-            }
             
-            if (_entropy.DoesTestStepsMetadataExist == true)
+            if (doesTestStepsMetadataExist)
             {
                 var testStepMetadataStr = JsonSerializer.Serialize<List<TestStepsMetadataJson>>(testStepsMetadata, new JsonSerializerOptions() {Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
                 control.Properties.Add(new PropertyNode()

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -141,7 +141,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
             var testStepsMetadata = new List<TestStepsMetadataJson>();
 
             // If no TestStepsMetadata were added in AfterRead, exit
-            if(_entropy.TestStepsMetadataEmpty == true){
+            if (_entropy.TestStepsMetadataEmpty == true)
+            {
                 return;
             }
 

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -212,11 +212,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
                     Expression = new ExpressionNode() { Expression = Utilities.EscapePAString(testStepMetadataStr) },
                     Identifier = _metadataPropName
                 });
-
-
-                control.Children = new List<BlockNode>();
-
             }
+                control.Children = new List<BlockNode>();
         }
     }
 }

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -29,6 +29,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
         private IList<KeyValuePair<string, string>> _screenIdToScreenName;
         private ErrorContainer _errors;
 
+        private Entropy _entropy;
+
         public static bool IsTestSuite(string templateName)
         {
             return templateName == "TestSuite";
@@ -50,6 +52,9 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
 
         public void AfterRead(BlockNode control)
         {
+
+            _entropy.TestStepsMetadataEmpty = true;
+
             var properties = control.Properties.ToDictionary(prop => prop.Identifier);
             if (!properties.TryGetValue(_metadataPropName, out var metadataProperty))
             {
@@ -68,6 +73,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
 
             foreach (var testStep in testStepsMetadata)
             {
+                _entropy.TestStepsMetadataEmpty = false;
+
                 if (!properties.TryGetValue(testStep.Rule, out var testStepProp))
                 {
                     _errors.ValidationError($"Unable to find corresponding property for test step {testStep.Rule} in {control.Name.Identifier}");
@@ -130,52 +137,55 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
         {
             var testStepsMetadata = new List<TestStepsMetadataJson>();
 
-            foreach (var child in control.Children)
-            {
-                var propName = child.Name.Identifier;
-                if (child.Name.Kind.TypeName != _testStepTemplateName)
+            if(_entropy.TestStepsMetadataEmpty == true){
+                
+                foreach (var child in control.Children)
                 {
-                    _errors.ValidationError($"Only controls of type {_testStepTemplateName} are valid children of a TestCase");
-                    throw new DocumentException();
-                }
-                if (child.Properties.Count > 3)
-                {
-                    _errors.ValidationError($"Test Step {propName} has unexpected properties");
-                }
-                var descriptionProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Description");
-                if (descriptionProp == null)
-                {
-                    _errors.ValidationError($"Test Step {propName} is missing a Description property");
-                    throw new DocumentException();
-                }
-                var valueProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Value");
-                if (valueProp == null)
-                {
-                    _errors.ValidationError($"Test Step {propName} is missing a Value property");
-                    throw new DocumentException();
-                }
-                var screenProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Screen");
+                    var propName = child.Name.Identifier;
+                    if (child.Name.Kind.TypeName != _testStepTemplateName)
+                    {
+                        _errors.ValidationError($"Only controls of type {_testStepTemplateName} are valid children of a TestCase");
+                        throw new DocumentException();
+                    }
+                    if (child.Properties.Count > 3)
+                    {
+                        _errors.ValidationError($"Test Step {propName} has unexpected properties");
+                    }
+                    var descriptionProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Description");
+                    if (descriptionProp == null)
+                    {
+                        _errors.ValidationError($"Test Step {propName} is missing a Description property");
+                        throw new DocumentException();
+                    }
+                    var valueProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Value");
+                    if (valueProp == null)
+                    {
+                        _errors.ValidationError($"Test Step {propName} is missing a Value property");
+                        throw new DocumentException();
+                    }
+                    var screenProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Screen");
 
-                string screenId = null;
-                // Lookup screenID by Name
-                if (screenProp != null && !_screenIdToScreenName.ToDictionary(kvp => kvp.Value, kvp => kvp.Key).TryGetValue(screenProp.Expression.Expression, out screenId))
-                {
-                    _errors.ValidationError($"Test Step {propName} references screen {screenProp.Expression.Expression} that is not present in the app");
-                    throw new DocumentException();
+                    string screenId = null;
+                    // Lookup screenID by Name
+                    if (screenProp != null && !_screenIdToScreenName.ToDictionary(kvp => kvp.Value, kvp => kvp.Key).TryGetValue(screenProp.Expression.Expression, out screenId))
+                    {
+                        _errors.ValidationError($"Test Step {propName} references screen {screenProp.Expression.Expression} that is not present in the app");
+                        throw new DocumentException();
+                    }
+
+                    testStepsMetadata.Add(new TestStepsMetadataJson()
+                    {
+                        Description = Utilities.UnEscapePAString(descriptionProp.Expression.Expression),
+                        Rule = propName,
+                        ScreenId = screenId
+                    });
+
+                    control.Properties.Add(new PropertyNode()
+                    {
+                        Expression = valueProp.Expression,
+                        Identifier = propName
+                    });
                 }
-
-                testStepsMetadata.Add(new TestStepsMetadataJson()
-                {
-                    Description = Utilities.UnEscapePAString(descriptionProp.Expression.Expression),
-                    Rule = propName,
-                    ScreenId = screenId
-                });
-
-                control.Properties.Add(new PropertyNode()
-                {
-                    Expression = valueProp.Expression,
-                    Identifier = propName
-                });
             }
             var testStepMetadataStr = JsonSerializer.Serialize<List<TestStepsMetadataJson>>(testStepsMetadata, new JsonSerializerOptions() {Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
             control.Properties.Add(new PropertyNode()

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -138,7 +138,11 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
 
         public void BeforeWrite(BlockNode control)
         {
-
+            // If TestStepsMetadata does not exist, return early
+            if (!_entropy.DoesTestStepsMetadataExist)
+            {
+                return;
+            }
 
             var testStepsMetadata = new List<TestStepsMetadataJson>();
 

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -138,11 +138,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
 
         public void BeforeWrite(BlockNode control)
         {
-            // If TestStepsMetadata does not exist, return early
-            if (!_entropy.DoesTestStepsMetadataExist)
-            {
-                return;
-            }
+
 
             var testStepsMetadata = new List<TestStepsMetadataJson>();
 

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -137,8 +137,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
         {
             var testStepsMetadata = new List<TestStepsMetadataJson>();
 
-            if(_entropy.TestStepsMetadataEmpty == true){
-                
+            if (_entropy.TestStepsMetadataEmpty == true)
+            {
                 foreach (var child in control.Children)
                 {
                     var propName = child.Name.Identifier;

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -29,6 +29,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
         private IList<KeyValuePair<string, string>> _screenIdToScreenName;
         private ErrorContainer _errors;
 
+        // To hold entropy passed in by constructor
         private Entropy _entropy;
 
         public static bool IsTestSuite(string templateName)
@@ -53,7 +54,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
 
         public void AfterRead(BlockNode control)
         {
-
+            // Say that TestStepsMetadata is empty, by default
             _entropy.TestStepsMetadataEmpty = true;
 
             var properties = control.Properties.ToDictionary(prop => prop.Identifier);
@@ -74,6 +75,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
 
             foreach (var testStep in testStepsMetadata)
             {
+                // If ever encountering TestStepsMetadata, set empty to false
                 _entropy.TestStepsMetadataEmpty = false;
 
                 if (!properties.TryGetValue(testStep.Rule, out var testStepProp))
@@ -138,7 +140,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
         {
             var testStepsMetadata = new List<TestStepsMetadataJson>();
 
-            if (_entropy.TestStepsMetadataEmpty == true)
+            // If there were TestStepsMetadata in AfterRead, allow code to run
+            if (_entropy.TestStepsMetadataEmpty == false)
             {
                 foreach (var child in control.Children)
                 {

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -138,12 +138,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
 
         public void BeforeWrite(BlockNode control)
         {
-            // If TestStepsMetadata does not exist, return early
-            if (!_entropy.DoesTestStepsMetadataExist)
-            {
-                return;
-            }
-
             var testStepsMetadata = new List<TestStepsMetadataJson>();
 
             foreach (var child in control.Children)
@@ -193,6 +187,13 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
                     Identifier = propName
                 });
             }
+            
+            // If TestStepsMetadata does not exist, return early
+            if (!_entropy.DoesTestStepsMetadataExist)
+            {
+                return;
+            }
+
             var testStepMetadataStr = JsonSerializer.Serialize<List<TestStepsMetadataJson>>(testStepsMetadata, new JsonSerializerOptions() {Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
             control.Properties.Add(new PropertyNode()
             {

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -140,58 +140,56 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
         {
             var testStepsMetadata = new List<TestStepsMetadataJson>();
 
-            // If no TestStepsMetadata were added in AfterRead, exit
-            if (_entropy.TestStepsMetadataEmpty == true)
+            // If no TestStepsMetadata were added in AfterRead, do not add
+            if (_entropy.TestStepsMetadataEmpty == false)
             {
-                return;
-            }
+                foreach (var child in control.Children)
+                {
+                    var propName = child.Name.Identifier;
+                    if (child.Name.Kind.TypeName != _testStepTemplateName)
+                    {
+                        _errors.ValidationError($"Only controls of type {_testStepTemplateName} are valid children of a TestCase");
+                        throw new DocumentException();
+                    }
+                    if (child.Properties.Count > 3)
+                    {
+                        _errors.ValidationError($"Test Step {propName} has unexpected properties");
+                    }
+                    var descriptionProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Description");
+                    if (descriptionProp == null)
+                    {
+                        _errors.ValidationError($"Test Step {propName} is missing a Description property");
+                        throw new DocumentException();
+                    }
+                    var valueProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Value");
+                    if (valueProp == null)
+                    {
+                        _errors.ValidationError($"Test Step {propName} is missing a Value property");
+                        throw new DocumentException();
+                    }
+                    var screenProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Screen");
 
-            foreach (var child in control.Children)
-            {
-                var propName = child.Name.Identifier;
-                if (child.Name.Kind.TypeName != _testStepTemplateName)
-                {
-                    _errors.ValidationError($"Only controls of type {_testStepTemplateName} are valid children of a TestCase");
-                    throw new DocumentException();
-                }
-                if (child.Properties.Count > 3)
-                {
-                    _errors.ValidationError($"Test Step {propName} has unexpected properties");
-                }
-                var descriptionProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Description");
-                if (descriptionProp == null)
-                {
-                    _errors.ValidationError($"Test Step {propName} is missing a Description property");
-                    throw new DocumentException();
-                }
-                var valueProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Value");
-                if (valueProp == null)
-                {
-                    _errors.ValidationError($"Test Step {propName} is missing a Value property");
-                    throw new DocumentException();
-                }
-                var screenProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Screen");
+                    string screenId = null;
+                    // Lookup screenID by Name
+                    if (screenProp != null && !_screenIdToScreenName.ToDictionary(kvp => kvp.Value, kvp => kvp.Key).TryGetValue(screenProp.Expression.Expression, out screenId))
+                    {
+                        _errors.ValidationError($"Test Step {propName} references screen {screenProp.Expression.Expression} that is not present in the app");
+                        throw new DocumentException();
+                    }
 
-                string screenId = null;
-                // Lookup screenID by Name
-                if (screenProp != null && !_screenIdToScreenName.ToDictionary(kvp => kvp.Value, kvp => kvp.Key).TryGetValue(screenProp.Expression.Expression, out screenId))
-                {
-                    _errors.ValidationError($"Test Step {propName} references screen {screenProp.Expression.Expression} that is not present in the app");
-                    throw new DocumentException();
+                    testStepsMetadata.Add(new TestStepsMetadataJson()
+                    {
+                        Description = Utilities.UnEscapePAString(descriptionProp.Expression.Expression),
+                        Rule = propName,
+                        ScreenId = screenId
+                    });
+
+                    control.Properties.Add(new PropertyNode()
+                    {
+                        Expression = valueProp.Expression,
+                        Identifier = propName
+                    });
                 }
-
-                testStepsMetadata.Add(new TestStepsMetadataJson()
-                {
-                    Description = Utilities.UnEscapePAString(descriptionProp.Expression.Expression),
-                    Rule = propName,
-                    ScreenId = screenId
-                });
-
-                control.Properties.Add(new PropertyNode()
-                {
-                    Expression = valueProp.Expression,
-                    Identifier = propName
-                });
             }
             var testStepMetadataStr = JsonSerializer.Serialize<List<TestStepsMetadataJson>>(testStepsMetadata, new JsonSerializerOptions() {Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
             control.Properties.Add(new PropertyNode()

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -141,7 +141,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
             var testStepsMetadata = new List<TestStepsMetadataJson>();
 
             // If no TestStepsMetadata were added in AfterRead, exit
-            if (_entropy.TestStepsMetadataEmpty)
+            if (_entropy.TestStepsMetadataEmpty == true)
             {
                 return;
             }

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -50,13 +50,13 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
 
             _entropy = entropy;
             _errors = errors;
+
+            // Say that TestStepsMetadata is empty, by default
+            _entropy.TestStepsMetadataEmpty = true;
         }
 
         public void AfterRead(BlockNode control)
         {
-            // Say that TestStepsMetadata is empty, by default
-            _entropy.TestStepsMetadataEmpty = true;
-
             var properties = control.Properties.ToDictionary(prop => prop.Identifier);
             if (!properties.TryGetValue(_metadataPropName, out var metadataProperty))
             {

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -141,7 +141,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
             var testStepsMetadata = new List<TestStepsMetadataJson>();
 
             // If no TestStepsMetadata were added in AfterRead, exit
-            if (_entropy.TestStepsMetadataEmpty == true)
+            if (_entropy.TestStepsMetadataEmpty)
             {
                 return;
             }

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -140,57 +140,60 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
         {
             var testStepsMetadata = new List<TestStepsMetadataJson>();
 
-            // If there were TestStepsMetadata in AfterRead, allow code to run
-            if (_entropy.TestStepsMetadataEmpty == false)
+            // If there weren't TestStepsMetadata in AfterRead, exit
+            if (_entropy.TestStepsMetadataEmpty == true)
             {
-                foreach (var child in control.Children)
-                {
-                    var propName = child.Name.Identifier;
-                    if (child.Name.Kind.TypeName != _testStepTemplateName)
-                    {
-                        _errors.ValidationError($"Only controls of type {_testStepTemplateName} are valid children of a TestCase");
-                        throw new DocumentException();
-                    }
-                    if (child.Properties.Count > 3)
-                    {
-                        _errors.ValidationError($"Test Step {propName} has unexpected properties");
-                    }
-                    var descriptionProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Description");
-                    if (descriptionProp == null)
-                    {
-                        _errors.ValidationError($"Test Step {propName} is missing a Description property");
-                        throw new DocumentException();
-                    }
-                    var valueProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Value");
-                    if (valueProp == null)
-                    {
-                        _errors.ValidationError($"Test Step {propName} is missing a Value property");
-                        throw new DocumentException();
-                    }
-                    var screenProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Screen");
-
-                    string screenId = null;
-                    // Lookup screenID by Name
-                    if (screenProp != null && !_screenIdToScreenName.ToDictionary(kvp => kvp.Value, kvp => kvp.Key).TryGetValue(screenProp.Expression.Expression, out screenId))
-                    {
-                        _errors.ValidationError($"Test Step {propName} references screen {screenProp.Expression.Expression} that is not present in the app");
-                        throw new DocumentException();
-                    }
-
-                    testStepsMetadata.Add(new TestStepsMetadataJson()
-                    {
-                        Description = Utilities.UnEscapePAString(descriptionProp.Expression.Expression),
-                        Rule = propName,
-                        ScreenId = screenId
-                    });
-
-                    control.Properties.Add(new PropertyNode()
-                    {
-                        Expression = valueProp.Expression,
-                        Identifier = propName
-                    });
-                }
+                return;
             }
+        
+            foreach (var child in control.Children)
+            {
+                var propName = child.Name.Identifier;
+                if (child.Name.Kind.TypeName != _testStepTemplateName)
+                {
+                    _errors.ValidationError($"Only controls of type {_testStepTemplateName} are valid children of a TestCase");
+                    throw new DocumentException();
+                }
+                if (child.Properties.Count > 3)
+                {
+                    _errors.ValidationError($"Test Step {propName} has unexpected properties");
+                }
+                var descriptionProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Description");
+                if (descriptionProp == null)
+                {
+                    _errors.ValidationError($"Test Step {propName} is missing a Description property");
+                    throw new DocumentException();
+                }
+                var valueProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Value");
+                if (valueProp == null)
+                {
+                    _errors.ValidationError($"Test Step {propName} is missing a Value property");
+                    throw new DocumentException();
+                }
+                var screenProp = child.Properties.FirstOrDefault(prop => prop.Identifier == "Screen");
+
+                string screenId = null;
+                // Lookup screenID by Name
+                if (screenProp != null && !_screenIdToScreenName.ToDictionary(kvp => kvp.Value, kvp => kvp.Key).TryGetValue(screenProp.Expression.Expression, out screenId))
+                {
+                    _errors.ValidationError($"Test Step {propName} references screen {screenProp.Expression.Expression} that is not present in the app");
+                    throw new DocumentException();
+                }
+
+                testStepsMetadata.Add(new TestStepsMetadataJson()
+                {
+                    Description = Utilities.UnEscapePAString(descriptionProp.Expression.Expression),
+                    Rule = propName,
+                    ScreenId = screenId
+                });
+
+                control.Properties.Add(new PropertyNode()
+                {
+                    Expression = valueProp.Expression,
+                    Identifier = propName
+                });
+            }
+        
             var testStepMetadataStr = JsonSerializer.Serialize<List<TestStepsMetadataJson>>(testStepsMetadata, new JsonSerializerOptions() {Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
             control.Properties.Add(new PropertyNode()
             {

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -47,6 +47,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
             _screenIdToScreenName = app._screens
                 .Select(screen => new KeyValuePair<string, string>(app._idRestorer.GetControlId(screen.Key).ToString(), screen.Key)).ToList();
 
+            _entropy = entropy;
             _errors = errors;
         }
 


### PR DESCRIPTION
Problem:
In some cases, when attempting to unpack an msapp using PALT, a TestStepsMetadata rule with empty InvariantScript property is being added after unpack during roundtrip causing a hash mismatch.

Solution:
Don't let a default TestStepsMetadate rule be added.
If one is added, throw an exception.