### PR TITLE
Handling asset path name collision 

### DIFF
--- a/src/PAModel/CanvasDocument.cs
+++ b/src/PAModel/CanvasDocument.cs
@@ -584,7 +584,16 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 var withoutPrefix = GetAssetFilePathWithoutPrefix(resource.Path);
                 fileEntry.Name = withoutPrefix;
                 _assetFiles.Remove(assetFilePath);
-                _assetFiles.Add(withoutPrefix, fileEntry);
+
+                if (_assetFiles.ContainsKey(withoutPrefix)) { 
+                    _assetFiles.Remove(withoutPrefix);
+                    _assetFiles.Add(withoutPrefix, fileEntry);
+                }
+                else
+                {
+                    _assetFiles.Add(withoutPrefix, fileEntry);
+                }
+                
 
                 // For every duplicate asset file an additional <filename>.json file is created which contains information like - originalName, newFileName.
                 if (resource.Name != originalName && !_localAssetInfoJson.ContainsKey(newFileName))

--- a/src/PAModelTests/NameCollisionTests.cs
+++ b/src/PAModelTests/NameCollisionTests.cs
@@ -173,5 +173,39 @@ namespace PAModelTests
                 Assert.AreEqual<int>(expectedControlsWithEditorState.Count, 0, $"{expectedControlsWithEditorState.Count} editor state files not found in EditorState directory.");
             }
         }
+
+        [TestMethod]
+        public void TestAssetPathCollision()
+        {
+            var doc = new CanvasDocument();
+            var resource1 = new ResourceJson()
+            {
+                Name = "Image", 
+                Path = "Assets\\Images\\Image.png",
+                FileName = "Image.png",
+                ResourceKind = ResourceKind.LocalFile,
+                Content = ContentKind.Image,
+            };
+
+            doc._assetFiles.Add(new FilePath("Images", "Image.png"), new FileEntry());
+            
+            var resource2 = new ResourceJson()
+            {
+                Name = "Image2", 
+                Path = "Assets\\Images\\Image.png",
+                FileName = "Image.png",
+                ResourceKind = ResourceKind.LocalFile,
+                Content = ContentKind.Image,
+            };
+
+            doc._assetFiles.Add(new FilePath("Images", "Image2.png"), new FileEntry());
+
+            doc._resourcesJson = new ResourcesJson() { Resources = new ResourceJson[] { resource1, resource2 } };
+
+            var errorContainer = new ErrorContainer();
+            doc.StabilizeAssetFilePaths(errorContainer);
+
+            Assert.IsFalse(errorContainer.HasErrors);
+        }
     }
 }


### PR DESCRIPTION
Problem: Asset file addition with same path name results in Error PA3001: Internal error. An item with the same key has already been added. ( CanvasDocument: StabilizeAssetFilePaths()).

Solution: Resolving the collision by removing the duplicate key before adding it back.