### PR TITLE
InvariantScript property of a control rule causing hash mismatch

### DIFF
--- a/docs/KnownIssues.md
+++ b/docs/KnownIssues.md
@@ -25,3 +25,14 @@ This can occur if the AllowAccessToGlobals field (associated with the Access app
 5. Unpack this new msapp
 
 The msapp should now unpack successfully without errors.
+
+## Warning PA2001: Checksum mismatch. File Controls\198.json checksum does not match on extract
+## Error   PA3013: Property Value Changed: TopParent.Children[4].Children[0].Rules[4].InvariantScript (or similar)
+
+This can occur if the function property InvariantScript value of controls with component definition set to false is not in sync with the same field in the Component definition. This can be resolved by the following steps -
+
+1. Open the msapp back into the Power Apps Studio
+2. Save and download this app back to your workspace
+3. Unpack this new msapp
+
+The msapp should now unpack successfully without errors.

--- a/docs/KnownIssues.md
+++ b/docs/KnownIssues.md
@@ -26,7 +26,7 @@ This can occur if the AllowAccessToGlobals field (associated with the Access app
 
 The msapp should now unpack successfully without errors.
 
-## Warning PA2001: Checksum mismatch. File Controls\198.json checksum does not match on extract (or similar) \n Error   PA3013: Property Value Changed: TopParent.Children[4].Children[0].Rules[4].InvariantScript (or similar)
+## Warning PA2001: Checksum mismatch. File Controls\198.json checksum does not match on extract (or similar) AND Error   PA3013: Property Value Changed: TopParent.Children[4].Children[0].Rules[4].InvariantScript (or similar)
 
 This can occur if the function property InvariantScript value of controls with component definition set to false is not in sync with the same field in the component definition. This can be resolved by the following steps -
 

--- a/docs/KnownIssues.md
+++ b/docs/KnownIssues.md
@@ -26,7 +26,7 @@ This can occur if the AllowAccessToGlobals field (associated with the Access app
 
 The msapp should now unpack successfully without errors.
 
-## Warning PA2001: Checksum mismatch. File Controls\198.json checksum does not match on extract (or similar) with Error   PA3013: Property Value Changed: TopParent.Children[4].Children[0].Rules[4].InvariantScript (or similar)
+## Warning PA2001: Checksum mismatch. File Controls\198.json checksum does not match on extract (or similar) \n Error   PA3013: Property Value Changed: TopParent.Children[4].Children[0].Rules[4].InvariantScript (or similar)
 
 This can occur if the function property InvariantScript value of controls with component definition set to false is not in sync with the same field in the component definition. This can be resolved by the following steps -
 

--- a/docs/KnownIssues.md
+++ b/docs/KnownIssues.md
@@ -26,8 +26,7 @@ This can occur if the AllowAccessToGlobals field (associated with the Access app
 
 The msapp should now unpack successfully without errors.
 
-## Warning PA2001: Checksum mismatch. File Controls\198.json checksum does not match on extract
-## Error   PA3013: Property Value Changed: TopParent.Children[4].Children[0].Rules[4].InvariantScript (or similar)
+## Warning PA2001: Checksum mismatch. File Controls\198.json checksum does not match on extract (or similar) Error   PA3013: Property Value Changed: TopParent.Children[4].Children[0].Rules[4].InvariantScript (or similar)
 
 This can occur if the function property InvariantScript value of controls with component definition set to false is not in sync with the same field in the Component definition. This can be resolved by the following steps -
 

--- a/docs/KnownIssues.md
+++ b/docs/KnownIssues.md
@@ -26,9 +26,9 @@ This can occur if the AllowAccessToGlobals field (associated with the Access app
 
 The msapp should now unpack successfully without errors.
 
-## Warning PA2001: Checksum mismatch. File Controls\198.json checksum does not match on extract (or similar) Error   PA3013: Property Value Changed: TopParent.Children[4].Children[0].Rules[4].InvariantScript (or similar)
+## Warning PA2001: Checksum mismatch. File Controls\198.json checksum does not match on extract (or similar) with Error   PA3013: Property Value Changed: TopParent.Children[4].Children[0].Rules[4].InvariantScript (or similar)
 
-This can occur if the function property InvariantScript value of controls with component definition set to false is not in sync with the same field in the Component definition. This can be resolved by the following steps -
+This can occur if the function property InvariantScript value of controls with component definition set to false is not in sync with the same field in the component definition. This can be resolved by the following steps -
 
 1. Open the msapp back into the Power Apps Studio
 2. Save and download this app back to your workspace


### PR DESCRIPTION
Problem: 
- Function property InvariantScript value of controls with component definition set to false should be in sync with its component definition InvariantScript value.

Solution:
- Update the knownIssue doc
![image](https://user-images.githubusercontent.com/98551644/165341876-dce53dc5-0f35-40cc-a6c1-914a302d124a.png)
