### PR TITLE
Handle Null Reference thrown in EnsureFileDirExists

### DIFF
--- a/src/PAModel/Serializers/MsAppSerializer.cs
+++ b/src/PAModel/Serializers/MsAppSerializer.cs
@@ -453,7 +453,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             }
 
             var checksum = new ChecksumMaker();
-            
+
             DirectoryWriter.EnsureFileDirExists(fullpathToMsApp);
             using (var z = ZipFile.Open(fullpathToMsApp, ZipArchiveMode.Create))
             {

--- a/src/PAModel/Serializers/MsAppSerializer.cs
+++ b/src/PAModel/Serializers/MsAppSerializer.cs
@@ -435,9 +435,9 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         {
             app.ApplyBeforeMsAppWriteTransforms(errors);
 
-            if (fullpathToMsApp == null)
+            if (String.IsNullOrEmpty(fullpathToMsApp))
             {
-                errors.BadParameter("Path to msapp cannot be null.");
+                errors.BadParameter("Path to msapp cannot be null or empty.");
                 return;
             }
             else if (!fullpathToMsApp.EndsWith(".msapp", StringComparison.OrdinalIgnoreCase) &&

--- a/src/PAModel/Serializers/MsAppSerializer.cs
+++ b/src/PAModel/Serializers/MsAppSerializer.cs
@@ -435,7 +435,11 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         {
             app.ApplyBeforeMsAppWriteTransforms(errors);
 
-            if (!fullpathToMsApp.EndsWith(".msapp", StringComparison.OrdinalIgnoreCase) &&
+            if (fullpathToMsApp == null){
+                errors.BadParameter("Path to msapp cannot be null.");
+                return;
+            }
+            else if (!fullpathToMsApp.EndsWith(".msapp", StringComparison.OrdinalIgnoreCase) &&
                 fullpathToMsApp.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
             {
                 errors.BadParameter("Only works for .msapp files");

--- a/src/PAModel/Serializers/MsAppSerializer.cs
+++ b/src/PAModel/Serializers/MsAppSerializer.cs
@@ -435,7 +435,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         {
             app.ApplyBeforeMsAppWriteTransforms(errors);
 
-            if (String.IsNullOrEmpty(fullpathToMsApp))
+            if (string.IsNullOrEmpty(fullpathToMsApp))
             {
                 errors.BadParameter("Path to msapp cannot be null or empty.");
                 return;

--- a/src/PAModel/Serializers/MsAppSerializer.cs
+++ b/src/PAModel/Serializers/MsAppSerializer.cs
@@ -435,7 +435,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         {
             app.ApplyBeforeMsAppWriteTransforms(errors);
 
-            if (fullpathToMsApp == null){
+            if (fullpathToMsApp == null)
+            {
                 errors.BadParameter("Path to msapp cannot be null.");
                 return;
             }

--- a/src/PAModel/Serializers/MsAppSerializer.cs
+++ b/src/PAModel/Serializers/MsAppSerializer.cs
@@ -453,7 +453,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             }
 
             var checksum = new ChecksumMaker();
-
+            
             DirectoryWriter.EnsureFileDirExists(fullpathToMsApp);
             using (var z = ZipFile.Open(fullpathToMsApp, ZipArchiveMode.Create))
             {

--- a/src/PAModel/Serializers/SourceSerializer.cs
+++ b/src/PAModel/Serializers/SourceSerializer.cs
@@ -249,6 +249,13 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             } // each loose file in '\other' 
 
             LoadDataSources(app, dir, errors);
+
+            if (templateDefaults == null)
+            {
+                errors.BadParameter("Template Defaults cannot be null.");
+                throw new DocumentException();
+            }
+
             LoadSourceFiles(app, dir, templateDefaults, errors);
 
             foreach (var file in dir.EnumerateFiles(ConnectionDir))

--- a/src/PAModel/Serializers/SourceSerializer.cs
+++ b/src/PAModel/Serializers/SourceSerializer.cs
@@ -249,13 +249,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             } // each loose file in '\other' 
 
             LoadDataSources(app, dir, errors);
-
-            if (templateDefaults == null)
-            {
-                errors.BadParameter("Template Defaults cannot be null.");
-                throw new DocumentException();
-            }
-
             LoadSourceFiles(app, dir, templateDefaults, errors);
 
             foreach (var file in dir.EnumerateFiles(ConnectionDir))


### PR DESCRIPTION
Handle null reference being thrown in EnsureFileDirExists:


```
System.NullReferenceException: Object reference not set to an instance of an object.

   at Microsoft.PowerPlatform.Formulas.Tools.DirectoryWriter.EnsureFileDirExists(String path)
```