### PR TITLE
Handling NullRefs: RestoreAssetFilePaths method

### DIFF
--- a/src/PAModel/CanvasDocument.cs
+++ b/src/PAModel/CanvasDocument.cs
@@ -624,7 +624,10 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             if (_entropy.LocalResourceFileNames == null)
                 return;
 
-            var maxFileNumber = FindMaxEntropyFileName();
+            if (_resourcesJson == null)
+                return;
+
+            var maxFileNumber = FindMaxEntropyFileName();          
 
             foreach (var resource in _resourcesJson.Resources)
             {

--- a/src/PAModelTests/WriteTransformTests.cs
+++ b/src/PAModelTests/WriteTransformTests.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.PowerPlatform.Formulas.Tools;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace PAModelTests
+{
+    [TestClass]
+    public class WriteTransformTests
+    {
+        [DataTestMethod]
+        [DataRow("EmptyTestCase.msapp")]
+        public void TestResourceNullCase(string filename)
+        {
+            var root = Path.Combine(Environment.CurrentDirectory, "Apps", filename);
+            Assert.IsTrue(File.Exists(root));
+
+            (var msapp, var errors) = CanvasDocument.LoadFromMsapp(root);
+            errors.ThrowOnErrors();
+
+            // explicitly setting it to null
+            msapp._resourcesJson = null;
+
+            msapp.ApplyBeforeMsAppWriteTransforms(errors);
+            Assert.IsFalse(errors.HasErrors);
+        }
+    }
+}


### PR DESCRIPTION
Resolving null reference exception in CanvasDocument.cs: RestoreAssetFilePaths()