### PR TITLE
Handle null reference thrown in EnsureFileDirExists

### DIFF
--- a/src/PAModel/Utility/DirectoryHelper.cs
+++ b/src/PAModel/Utility/DirectoryHelper.cs
@@ -129,6 +129,12 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         // Must pre-create it before writing. 
         public static void EnsureFileDirExists(string path)
         {
+            if (string.IsNullOrEmpty(path))
+            {
+                errors.BadParameter("Path to file directory cannot be null or empty.");
+                throw new DocumentException();
+            }
+
             System.IO.FileInfo file = new System.IO.FileInfo(path);
             file.Directory.Create(); // If the directory already exists, this method does nothing.
         }

--- a/src/PAModel/Utility/DirectoryHelper.cs
+++ b/src/PAModel/Utility/DirectoryHelper.cs
@@ -129,6 +129,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         // Must pre-create it before writing. 
         public static void EnsureFileDirExists(string path)
         {
+            var errors = new ErrorContainer();
+
             if (string.IsNullOrEmpty(path))
             {
                 errors.BadParameter("Path to file directory cannot be null or empty.");

--- a/src/PAModelTests/ErrorTests.cs
+++ b/src/PAModelTests/ErrorTests.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using Xunit;
 
 
+
 namespace PAModelTests
 {
     // Verify we get errors (and not exceptions). 
@@ -54,6 +55,13 @@ namespace PAModelTests
             (var doc, var errors) = CanvasDocument.LoadFromSources(PathMissingDir);
             Assert.True(errors.HasErrors);
             Assert.Null(doc);
+        }
+
+        [Fact]
+        public void BadWriteDir()
+        {
+            string path = null;
+            Assert.Throws<DocumentException>(() => DirectoryWriter.EnsureFileDirExists(path));   
         }
 
         [Theory]

--- a/src/PAModelTests/ErrorTests.cs
+++ b/src/PAModelTests/ErrorTests.cs
@@ -7,8 +7,6 @@ using System.IO;
 using System.Text.Json;
 using Xunit;
 
-
-
 namespace PAModelTests
 {
     // Verify we get errors (and not exceptions). 


### PR DESCRIPTION
Problem: Null reference gets thrown if dir string is null, when passed into EnsureFileDirExists.

Solution: Exit program, returning error and exception if dir string is null/empty.