### PR TITLE
Handling nullreference loadsourcefiles

### DIFF
--- a/src/PAModel/Serializers/SourceSerializer.cs
+++ b/src/PAModel/Serializers/SourceSerializer.cs
@@ -79,6 +79,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
         public static CanvasDocument LoadFromSource(string directory2, ErrorContainer errors)
         {
+
             if (File.Exists(directory2))
             {
                 if (directory2.EndsWith(".msapp", StringComparison.OrdinalIgnoreCase))
@@ -406,6 +407,14 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             foreach (var file in EnumerateComponentDirs(directory, "*.json"))
             {
                 var componentTemplate = file.ToObject<CombinedTemplateState>();
+
+                // adding this check since ComponentManifest this is default to null
+                if (componentTemplate.ComponentManifest == null)
+                {
+                    errors.GenericError("Could not find ComponentManifest for " + componentTemplate.ComponentType);
+                    throw new DocumentException();
+                }
+
                 app._templateStore.AddTemplate(componentTemplate.ComponentManifest.Name, componentTemplate);
             }
 

--- a/src/PAModel/Serializers/SourceSerializer.cs
+++ b/src/PAModel/Serializers/SourceSerializer.cs
@@ -401,7 +401,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             foreach (var file in EnumerateComponentDirs(directory, "*.fx.yaml"))
             {
                 AddControl(app, file._relativeName, true, file.GetContents(), errors);
-
             }
 
             foreach (var file in EnumerateComponentDirs(directory, "*.json"))

--- a/src/PAModel/Serializers/SourceSerializer.cs
+++ b/src/PAModel/Serializers/SourceSerializer.cs
@@ -79,7 +79,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
         public static CanvasDocument LoadFromSource(string directory2, ErrorContainer errors)
         {
-
             if (File.Exists(directory2))
             {
                 if (directory2.EndsWith(".msapp", StringComparison.OrdinalIgnoreCase))

--- a/src/PAModel/Serializers/SourceSerializer.cs
+++ b/src/PAModel/Serializers/SourceSerializer.cs
@@ -406,7 +406,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             {
                 var componentTemplate = file.ToObject<CombinedTemplateState>();
 
-                // adding this check since ComponentManifest this is default to null
+                // adding this check since ComponentManifest is default to null
                 if (componentTemplate.ComponentManifest == null)
                 {
                     errors.GenericError("Could not find ComponentManifest for " + componentTemplate.ComponentType);

--- a/src/PAModel/Serializers/SourceSerializer.cs
+++ b/src/PAModel/Serializers/SourceSerializer.cs
@@ -406,7 +406,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             {
                 var componentTemplate = file.ToObject<CombinedTemplateState>();
 
-                // adding this check since ComponentManifest is default to null
                 if (componentTemplate.ComponentManifest == null)
                 {
                     errors.GenericError("Could not find ComponentManifest for " + componentTemplate.ComponentType);


### PR DESCRIPTION
**Exception log:**
System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.PowerPlatform.Formulas.Tools.SourceSerializer.LoadSourceFiles(CanvasDocument app, DirectoryReader directory, Dictionary`2 templateDefaults, ErrorContainer errors)
   at Microsoft.PowerPlatform.Formulas.Tools.SourceSerializer.LoadFromSource(String directory2, ErrorContainer errors)
   at Microsoft.PowerPlatform.Formulas.Tools.CanvasDocument.<>c__DisplayClass31_0.<LoadFromSources>b__0()
   at Microsoft.PowerPlatform.Formulas.Tools.CanvasDocument.Wrapper(Func`1 worker, ErrorContainer errors)
   at Microsoft.PowerPlatform.Formulas.Tools.CanvasDocument.LoadFromSources(String pathToSourceDirectory)
   at Microsoft.PowerPlatform.Formulas.Tools.CanvasDocument.SaveToSources(String pathToSourceDirectory, String verifyOriginalPath)
   at Microsoft.AppMagic.Authoring.Document.ValidateALMRoundTrip(String path) in D:\a\_work\1\s\src\Cloud\DocumentServer.Core\Document\Document\Persistence\PostSaveALMCheck.cs:line 107

**Problem:** Seems to throw when ComponentManifest member is null for component
**Solution:** handle this by throwing exception since the value cannot be null.