### PR TITLE
Remove Validation Errors

### DIFF
--- a/src/PAModel/CanvasDocument.cs
+++ b/src/PAModel/CanvasDocument.cs
@@ -423,12 +423,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 {
                     template.DynamicControlDefinitionJson = PcfControl.GenerateDynamicControlDefinition(kvp.Value);
                 }
-                else
-                {
-                    // Validation for accidental deletion of ocf control templates.
-                    errors.ValidationError($"Could not find Pcf Control Template with name: {kvp.Key} in pkgs/PcfControlTemplates directory. " +
-                        $"If it was intentionally deleted, please delete the entry from ControlTemplates.json along with its references from source files.");
-                }
             }
 
             var componentInstanceTransform = new ComponentInstanceTransform(errors);

--- a/src/PAModel/PAConvert/ErrorCode.cs
+++ b/src/PAModel/PAConvert/ErrorCode.cs
@@ -141,16 +141,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             errors.AddError(ErrorCode.ParseError, span, $"Parse error: {message}");
         }
 
-        public static void ValidationError(this ErrorContainer errors, string message)
-        {
-            errors.AddError(ErrorCode.Validation, default(SourceLocation), $"Validation error: {message}");
-        }
-
-        public static void ValidationError(this ErrorContainer errors, SourceLocation span, string message)
-        {
-            errors.AddError(ErrorCode.Validation, span, $"Validation error: {message}");
-        }
-
         public static void MsAppFormatError(this ErrorContainer errors, string message)
         {
             errors.AddError(ErrorCode.CantReadMsApp, default(SourceLocation), $"MsApp is corrupted: {message}");

--- a/src/PAModel/Serializers/SourceSerializer.cs
+++ b/src/PAModel/Serializers/SourceSerializer.cs
@@ -778,13 +778,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                         dataSourceReferences.Add(tableDef.DatasetName, localDatabaseReferenceJson);
                     }
                 }
-                if (localDatabaseReferenceJson.instanceUrl != tableDef.InstanceUrl)
-                {
-                    // Generate an error, dataset defs have diverged in a way that shouldn't be possible
-                    // Each dataset has one instanceurl
-                    errors.ValidationError($"For file {file._relativeName}, the dataset {tableDef.DatasetName} has multiple instanceurls");
-                    throw new DocumentException();
-                }
 
                 if (tableDef.LocalReferenceDSJson != null)
                 {
@@ -1011,21 +1004,11 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 // If its a widget template then there must be a xml file in the pkgs directory.
                 if (templateState.IsWidgetTemplate)
                 {
-                    if (!app._templates.UsedTemplates.Any(x => x.Name == child.Name.Kind.TypeName))
-                    {
-                        errors.ValidationError(root.SourceSpan.GetValueOrDefault(), $"Widget control template: {templateState.TemplateDisplayName}, version {templateState.Version} was not found in the pkgs directory and is referred in {root.Name.Identifier}. " +
-                            $"If the template was deleted intentionally please make sure to update the source files to remove the references to this template.");
-                    }
                     continue;
                 }
                 // if its a component template then check if the template exists in the Src/Components directory
                 else if (templateState.IsComponentTemplate == true)
                 {
-                    if (!app._components.Keys.Any(x => x == child.Name.Kind.TypeName))
-                    {
-                        errors.ValidationError(root.SourceSpan.GetValueOrDefault(), $"Component template: {templateState.TemplateDisplayName} was not found in Src/Components directory and is referred in {root.Name.Identifier}. " +
-                            $"If the template was deleted intentionally please make sure to update the source files to remove the references to this template.");
-                    }
                     continue;
                 }
             }

--- a/src/PAModel/SourceTransforms/ComponentDefinitionTransform.cs
+++ b/src/PAModel/SourceTransforms/ComponentDefinitionTransform.cs
@@ -73,19 +73,11 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
                 return;
             }
 
-            if (!_templateStore.TryGetTemplate(controlName, out var componentTemplate) ||
-                !(componentTemplate.IsComponentTemplate ?? false))
-            {
-                _errors.ValidationError($"Unable to find template for component {controlName}");
-                throw new DocumentException();
-            }
 
+            _templateStore.TryGetTemplate(controlName, out var componentTemplate);
             var originalTemplateName = componentTemplate.Name;
-            if (!_templateStore.TryRenameTemplate(controlName, originalTemplateName))
-            {
-                _errors.ValidationError($"Unable to update template for component {controlName}, id {originalTemplateName}");
-                throw new DocumentException();
-            }
+            
+            _templateStore.TryRenameTemplate(controlName, originalTemplateName);
 
             _componentInstanceTransform.ComponentRenames.Add(controlName, originalTemplateName);
             control.Name.Kind.TypeName = originalTemplateName;

--- a/src/PAModel/SourceTransforms/ComponentInstanceTransform.cs
+++ b/src/PAModel/SourceTransforms/ComponentInstanceTransform.cs
@@ -41,10 +41,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
             {
                 control.Name.Kind.TypeName = rename;
             }
-            else
-            {
-                _errors.ValidationError("Renaming component instance but unable to find target name");
-            }
         }
     }
 }

--- a/src/PAModel/SourceTransforms/GroupControlTransform.cs
+++ b/src/PAModel/SourceTransforms/GroupControlTransform.cs
@@ -45,12 +45,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
             foreach (var groupControl in groupControls)
             {
                 var groupControlName = groupControl.Name.Identifier;
-                if (!_editorStateStore.TryGetControlState(groupControlName, out var groupControlState) || groupControlState.GroupedControlsKey.Count == 0)
-                {
-                    _errors.ValidationError($"Group control state is missing or empty for {groupControlName}");
-                    throw new DocumentException();
-                }
-
+                _editorStateStore.TryGetControlState(groupControlName, out var groupControlState);
+                
                 _entropy.AddGroupControl(groupControlState);
 
                 foreach (var childKey in groupControlState.GroupedControlsKey)
@@ -59,10 +55,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
                     {
                         groupControl.Children.Add(newChild);
                         peerControlsDict.Remove(childKey);
-                    }
-                    else
-                    {
-                        _errors.ValidationError($"Group control {groupControlName}'s state refers to non-existent child {childKey}");
                     }
                 }
                 groupControlState.GroupedControlsKey = null;


### PR DESCRIPTION
Problem: Validation should be on server side, not client side. We should not be throwing exceptions on validly generated apps.

Solution: Remove validation errors from PALT.