### PR TITLE
Updating YamlWriter for non-string types

### DIFF
--- a/src/PAModel/PAConvert/Yaml/YamlPocoSerializer.cs
+++ b/src/PAModel/PAConvert/Yaml/YamlPocoSerializer.cs
@@ -58,7 +58,7 @@ namespace Microsoft.PowerPlatform
                 // Exclude default values.
                 if (valBool)
                 {
-                    yaml.WriteProperty(propName, valBool);
+                    yaml.WriteProperty(propName, valBool, false);
                 }
             }
             else if (obj is string valString)
@@ -67,11 +67,11 @@ namespace Microsoft.PowerPlatform
             }
             else if (obj is int valInt)
             {
-                yaml.WriteProperty(propName, valInt);
+                yaml.WriteProperty(propName, valInt, false);
             }
             else if (obj is double valDouble)
             {
-                yaml.WriteProperty(propName, valDouble);
+                yaml.WriteProperty(propName, valDouble, false);
             }
             else if (obj.GetType().IsEnum)
             {

--- a/src/PAModel/PAConvert/Yaml/YamlWriter.cs
+++ b/src/PAModel/PAConvert/Yaml/YamlWriter.cs
@@ -45,27 +45,39 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Yaml
             }
         }
 
-        public void WriteProperty(string propertyName, bool value)
+        public void WriteProperty(string propertyName, bool value, bool includeEquals = true)
         {
             WriteIndent();
             _text.Write(propertyName);
             _text.Write(": ");
+            if (includeEquals)
+            {
+                _text.Write("=");
+            }
             _text.WriteLine(value ? "true" : "false");
         }
 
-        public void WriteProperty(string propertyName, int value)
+        public void WriteProperty(string propertyName, int value, bool includeEquals = true)
         {
             WriteIndent();
             _text.Write(propertyName);
             _text.Write(": ");
+            if (includeEquals)
+            {
+                _text.Write("=");
+            }
             _text.WriteLine(value);
         }
 
-        public void WriteProperty(string propertyName, double value)
+        public void WriteProperty(string propertyName, double value, bool includeEquals = true)
         {
             WriteIndent();
             _text.Write(propertyName);
             _text.Write(": ");
+            if (includeEquals)
+            {
+                _text.Write("=");
+            }
             _text.WriteLine(value);
         }
 

--- a/src/PAModelTests/YamlTest.cs
+++ b/src/PAModelTests/YamlTest.cs
@@ -109,6 +109,48 @@ Obj1:
             Assert.AreEqual(normalizedValue, NormNewlines(p.Value));
         }
 
+
+        [DataTestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public void WriteBool(bool value)
+        {
+            var sw = new StringWriter();
+            var yw = new YamlWriter(sw);
+            yw.WriteProperty("P0", value);
+
+            var t = sw.ToString();
+            var expected = $@"P0: ={value.ToString().ToLower()}
+";
+            Assert.AreEqual(expected.Replace("\r\n", "\n"), t.Replace("\r\n", "\n"));
+        }
+
+        [TestMethod]
+        public void WriteInt()
+        {
+            var sw = new StringWriter();
+            var yw = new YamlWriter(sw);
+            yw.WriteProperty("P0", 12);
+
+            var t = sw.ToString();
+            var expected = @"P0: =12
+";
+            Assert.AreEqual(expected.Replace("\r\n", "\n"), t.Replace("\r\n", "\n"));
+        }
+
+        [TestMethod]
+        public void WriteDouble()
+        {
+            var sw = new StringWriter();
+            var yw = new YamlWriter(sw);
+            yw.WriteProperty("P0", 1.2);
+
+            var t = sw.ToString();
+            var expected = @"P0: =1.2
+";
+            Assert.AreEqual(expected.Replace("\r\n", "\n"), t.Replace("\r\n", "\n"));
+        }
+
         // Normalize newlines across OSes. 
         static string NormNewlines(string x)
         {


### PR DESCRIPTION
Updating the YamlWriter class to append `=` for serialized values of type `int`, `double`, and `bool`. Without the `=` these will not be valid values in the Power App and have a formula warning when opening the App.

I believe this case was never encountered because `Visit` in PAWriterVisitor.cs turns everything to a string before writing the property:
https://github.com/microsoft/PowerApps-Language-Tooling/blob/e9c7885dbadfb467444e28ab4d15416fa032e28f/src/PAModel/PAConvert/PAWriterVisitor.cs#L109

The only other place these property types are being referenced directly is in YamlPocoSerializer, but this isn't used during the actual serialization of the Power App. I've updated it to be consistent with how it handles `string` types.

All test Apps continue to pass round-trip. Added some unit tests to cover this case as well.