### PR TITLE
OverridableProperties getting added/changed/removed

### DIFF
--- a/src/PAModel/Schemas/adhoc/Control.cs
+++ b/src/PAModel/Schemas/adhoc/Control.cs
@@ -94,7 +94,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                     template.ExtensionData.Add("FirstParty", true);
                     template.ExtensionData.Add("IsCustomGroupControlTemplate", false);
                     template.ExtensionData.Add("CustomGroupControlTemplateName", "");
-                    template.ExtensionData.Add("OverridableProperties", new object());
                 }
                 return template;
             }


### PR DESCRIPTION
**Problem:** These errors are throwing:

- Property Added: TopParent.Children[\*].Template.OverridableProperties.*
- Property Removed: TopParent.Children[\*].Template.OverridableProperties.*
- Property Changed: TopParent.Children[\*].Template.OverridableProperties.*

**Solution:** It's possible that this is occurring because some back-compatibility issue needs to be handled.