### PR TITLE
Handling AllowAccessToGlobals property not in sync

### DIFF
--- a/src/PAModel/IR/IRStateHelpers.cs
+++ b/src/PAModel/IR/IRStateHelpers.cs
@@ -175,7 +175,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             else
             {
                 templateState = new CombinedTemplateState(control.Template);
-                templateState.ComponentDefinitionInfo = null;
+                templateState.ComponentDefinitionInfo = control.Template.ComponentDefinitionInfo;
                 var templateName = templateState.TemplateDisplayName ?? templateState.Name;
                 templateStore.AddTemplate(templateName, templateState);
             }
@@ -321,6 +321,15 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                     }
                 }
 
+                if (template.ComponentDefinitionInfo != null)
+                {
+                    if (state.AllowAccessToGlobals != template.ComponentDefinitionInfo.AllowAccessToGlobals && state.IsComponentDefinition == false)
+                    {
+                        // state.AllowAccessToGlobals = templateState.ComponentDefinitionInfo?.AllowAccessToGlobals ?? state.AllowAccessToGlobals;
+                       //  Console.WriteLine("Component Manifest allowaccesstoglobals not in sync with instance property value" + controlName);
+                    }
+                }
+
                 // Preserve ordering from serialized IR
                 // Required for roundtrip checks
                 properties = properties.OrderBy(prop => state.Properties?.Select(propState => propState.PropertyName).ToList().IndexOf(prop.Property) ?? -1).ToList();
@@ -337,15 +346,16 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                     ExtensionData = state.ExtensionData,
                     IsGroupControl = state.IsGroupControl,
                     GroupedControlsKey = state.GroupedControlsKey,
-                    AllowAccessToGlobals = state.AllowAccessToGlobals,
+                    AllowAccessToGlobals = (state.IsComponentDefinition ?? false) ? (templateState?.ComponentDefinitionInfo?.AllowAccessToGlobals) ?? state.AllowAccessToGlobals : state.AllowAccessToGlobals,
                 };
 
                 if (state.IsComponentDefinition ?? false)
                 {
-                    // Before AllowAccessToGlobals added to ComponentDefinition in msapp, it is present in component manifest as well.
-                    // So when reconstructing componentdefinition, we need to identify if it was ever present on component definition or not.
-                    // For this, we use state IsAllowAccessToGlobalsPresent.
-                    templateState.ComponentDefinitionInfo = new ComponentDefinitionInfoJson(resultControlInfo, template.LastModifiedTimestamp, orderedChildren, entropy.IsLegacyComponentAllowGlobalScopeCase ? null : state.AllowAccessToGlobals);
+                    // There seems to situation where component manifest AllowAccessToGlobals could be out of sync with instance AllowAccessToGlobals value
+                    // But ComponentDefinitionInfo AllowAccessToGlobals property value is considered the source of truth, hence using it
+                    // When reconstructing componentdefinition, we need to track, whether msapp has AllowGlobalScope property in component instance
+                    // For this, we use state IsLegacyComponentAllowGlobalScopeCase.
+                    templateState.ComponentDefinitionInfo = new ComponentDefinitionInfoJson(resultControlInfo, template.LastModifiedTimestamp, orderedChildren, entropy.IsLegacyComponentAllowGlobalScopeCase ? null : (templateState.ComponentDefinitionInfo?.AllowAccessToGlobals ?? state.AllowAccessToGlobals));
                     template = templateState.ToControlInfoTemplate();
                     template.IsComponentDefinition = true;
 

--- a/src/PAModel/IR/IRStateHelpers.cs
+++ b/src/PAModel/IR/IRStateHelpers.cs
@@ -337,7 +337,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                     ExtensionData = state.ExtensionData,
                     IsGroupControl = state.IsGroupControl,
                     GroupedControlsKey = state.GroupedControlsKey,
-                    AllowAccessToGlobals = (state.IsComponentDefinition ?? false) ? templateState?.ComponentManifest?.AllowAccessToGlobals : state.AllowAccessToGlobals,
+                    AllowAccessToGlobals = state.AllowAccessToGlobals,
                 };
 
                 if (state.IsComponentDefinition ?? false)
@@ -345,7 +345,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                     // Before AllowAccessToGlobals added to ComponentDefinition in msapp, it is present in component manifest as well.
                     // So when reconstructing componentdefinition, we need to identify if it was ever present on component definition or not.
                     // For this, we use state IsAllowAccessToGlobalsPresent.
-                    templateState.ComponentDefinitionInfo = new ComponentDefinitionInfoJson(resultControlInfo, template.LastModifiedTimestamp, orderedChildren, entropy.IsLegacyComponentAllowGlobalScopeCase ? null : templateState.ComponentManifest.AllowAccessToGlobals);
+                    templateState.ComponentDefinitionInfo = new ComponentDefinitionInfoJson(resultControlInfo, template.LastModifiedTimestamp, orderedChildren, entropy.IsLegacyComponentAllowGlobalScopeCase ? null : state.AllowAccessToGlobals);
                     template = templateState.ToControlInfoTemplate();
                     template.IsComponentDefinition = true;
 

--- a/src/PAModel/IR/IRStateHelpers.cs
+++ b/src/PAModel/IR/IRStateHelpers.cs
@@ -342,8 +342,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
                 if (state.IsComponentDefinition ?? false)
                 {
-                    // There seems to situation where component manifest AllowAccessToGlobals could be out of sync with instance AllowAccessToGlobals value
-                    // But ComponentDefinitionInfo AllowAccessToGlobals property value is considered the source of truth, hence using it
+                    // There seems to situation where ComponentManifest AllowAccessToGlobals is out of sync with instance AllowAccessToGlobals value
+                    // But ComponentDefinitionInfo AllowAccessToGlobals property value is the source of truth, hence using it
                     // When reconstructing componentdefinition, we need to track, whether msapp has AllowGlobalScope property in component instance
                     // For this, we use state IsLegacyComponentAllowGlobalScopeCase.
                     templateState.ComponentDefinitionInfo = new ComponentDefinitionInfoJson(resultControlInfo, template.LastModifiedTimestamp, orderedChildren, entropy.IsLegacyComponentAllowGlobalScopeCase ? null : (templateState.ComponentDefinitionInfo?.AllowAccessToGlobals ?? state.AllowAccessToGlobals));

--- a/src/PAModel/IR/IRStateHelpers.cs
+++ b/src/PAModel/IR/IRStateHelpers.cs
@@ -344,7 +344,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 {
                     // There seems to situation where ComponentManifest AllowAccessToGlobals is out of sync with instance AllowAccessToGlobals value
                     // But ComponentDefinitionInfo AllowAccessToGlobals property value is the source of truth, hence using it
-                    // When reconstructing componentdefinition, we need to track, whether msapp has AllowGlobalScope property in component instance
+                    // When reconstructing componentdefinition, we need to track whether msapp has AllowGlobalScope property in component instance
                     // For this, we use state IsLegacyComponentAllowGlobalScopeCase.
                     templateState.ComponentDefinitionInfo = new ComponentDefinitionInfoJson(resultControlInfo, template.LastModifiedTimestamp, orderedChildren, entropy.IsLegacyComponentAllowGlobalScopeCase ? null : (templateState.ComponentDefinitionInfo?.AllowAccessToGlobals ?? state.AllowAccessToGlobals));
                     template = templateState.ToControlInfoTemplate();

--- a/src/PAModel/IR/IRStateHelpers.cs
+++ b/src/PAModel/IR/IRStateHelpers.cs
@@ -321,15 +321,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                     }
                 }
 
-                if (template.ComponentDefinitionInfo != null)
-                {
-                    if (state.AllowAccessToGlobals != template.ComponentDefinitionInfo.AllowAccessToGlobals && state.IsComponentDefinition == false)
-                    {
-                        // state.AllowAccessToGlobals = templateState.ComponentDefinitionInfo?.AllowAccessToGlobals ?? state.AllowAccessToGlobals;
-                       //  Console.WriteLine("Component Manifest allowaccesstoglobals not in sync with instance property value" + controlName);
-                    }
-                }
-
                 // Preserve ordering from serialized IR
                 // Required for roundtrip checks
                 properties = properties.OrderBy(prop => state.Properties?.Select(propState => propState.PropertyName).ToList().IndexOf(prop.Property) ?? -1).ToList();


### PR DESCRIPTION
Problem : AllowAccessToGlobals property should be in-sync across custom components, their instances and metadata . Currently there are instance where its not in-sync. Telemetry shows quite a lot of these errors reported.

Solution: Using ComponentDefinitionInfo AllowAccessToGlobals property value over ComponentManifest.AllowAccessToGlobals since ComponentDefinitionInfo values are source of truth

Validation: Roundtrips all test .msapps in test battery and in this repo without errors. Roundtrips validation successful for customer .msapp with this inconsistency.