### PR TITLE
Create Backdoor REPL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -357,3 +357,7 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Jetbrains IDE files
+.idea/
+.run/

--- a/src/Backdoor/Backdoor.csproj
+++ b/src/Backdoor/Backdoor.csproj
@@ -49,7 +49,9 @@
         <Compile Include="Repl\Functions\ListControls.cs" />
         <Compile Include="Repl\Functions\ListFunctions\ListChildren.cs" />
         <Compile Include="Repl\Functions\ListFunctions\ListScreens.cs" />
+        <Compile Include="Repl\Functions\Open.cs" />
         <Compile Include="Repl\Functions\Pack.cs" />
+        <Compile Include="Repl\Functions\Result\Result.cs" />
         <Compile Include="Repl\Functions\SaveToFileFunction.cs" />
         <Compile Include="Repl\Functions\ToSource.cs" />
         <Compile Include="Repl\Menus\IMenu.cs" />

--- a/src/Backdoor/Backdoor.csproj
+++ b/src/Backdoor/Backdoor.csproj
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+    <PropertyGroup>
+        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+        <ProjectGuid>{90CFC486-A80D-4668-8C00-BB6EDEF9EF36}</ProjectGuid>
+        <OutputType>Exe</OutputType>
+        <AppDesignerFolder>Properties</AppDesignerFolder>
+        <RootNamespace>Backdoor</RootNamespace>
+        <AssemblyName>Backdoor</AssemblyName>
+        <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+        <FileAlignment>512</FileAlignment>
+        <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+        <LangVersion>9</LangVersion>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <DebugSymbols>true</DebugSymbols>
+        <DebugType>full</DebugType>
+        <Optimize>false</Optimize>
+        <OutputPath>bin\Debug\</OutputPath>
+        <DefineConstants>DEBUG;TRACE</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <DebugType>pdbonly</DebugType>
+        <Optimize>true</Optimize>
+        <OutputPath>bin\Release\</OutputPath>
+        <DefineConstants>TRACE</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+    <ItemGroup>
+        <Reference Include="System" />
+        <Reference Include="System.Core" />
+        <Reference Include="System.Data" />
+        <Reference Include="System.Xml" />
+    </ItemGroup>
+    <ItemGroup>
+        <Compile Include="BackdoorError.cs" />
+        <Compile Include="Program.cs" />
+        <Compile Include="Properties\AssemblyInfo.cs" />
+        <Compile Include="Repl\Functions\Delete.cs" />
+        <Compile Include="Repl\Functions\Exit.cs" />
+        <Compile Include="Repl\Functions\IFunction.cs" />
+        <Compile Include="Repl\Functions\ListControls.cs" />
+        <Compile Include="Repl\Functions\ListFunctions\ListChildren.cs" />
+        <Compile Include="Repl\Functions\ListFunctions\ListScreens.cs" />
+        <Compile Include="Repl\Functions\Pack.cs" />
+        <Compile Include="Repl\Functions\SaveToFileFunction.cs" />
+        <Compile Include="Repl\Functions\ToSource.cs" />
+        <Compile Include="Repl\Menus\IMenu.cs" />
+        <Compile Include="Repl\Menus\ReplMenu.cs" />
+        <Compile Include="Repl\Parser.cs" />
+        <Compile Include="Repl\Repl.cs" />
+        <Compile Include="Util\Utility.cs" />
+    </ItemGroup>
+    <ItemGroup>
+      <ProjectReference Include="..\PAModel\Microsoft.PowerPlatform.Formulas.Tools.csproj">
+        <Project>{48316d0e-4a8a-461c-9c56-9cae8f2e208f}</Project>
+        <Name>Microsoft.PowerPlatform.Formulas.Tools</Name>
+      </ProjectReference>
+    </ItemGroup>
+    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="4.7.2" />
+    </ItemGroup>
+    <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+         Other similar extension points exist, see Microsoft.Common.targets.
+    <Target Name="BeforeBuild">
+    </Target>
+    <Target Name="AfterBuild">
+    </Target>
+    -->
+
+</Project>

--- a/src/Backdoor/BackdoorError.cs
+++ b/src/Backdoor/BackdoorError.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.PowerPlatform.Formulas.Tools.PAConvert;
+
+namespace Backdoor
+{
+    public class BackdoorError : IError
+    {
+        private string _message;
+
+        public BackdoorError(bool isError, bool isWarning, string message)
+        {
+            IsError = isError;
+            IsWarning = isWarning;
+            _message = message;
+        }
+
+        public bool IsError { get; }
+        public bool IsWarning { get; }
+        public override string ToString() => _message;
+    }
+}

--- a/src/Backdoor/Program.cs
+++ b/src/Backdoor/Program.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Backdoor.Repl;
+using Backdoor.Repl.Menus;
+using Backdoor.Util;
+using Microsoft.PowerPlatform.Formulas.Tools;
+using Microsoft.PowerPlatform.Formulas.Tools.PAConvert;
+
+Console.CancelKeyPress += (sender, cancelArgs) =>
+{
+    if (cancelArgs.SpecialKey == ConsoleSpecialKey.ControlC)
+    {
+        cancelArgs.Cancel = true;
+        Environment.Exit(0);
+    }
+};
+
+if (args == null || args.Length != 1)
+{
+    Console.WriteLine("Input only a single argument");
+    return;
+}
+
+var msAppPath = Path.GetFullPath(args[0]);
+if (!File.Exists(msAppPath))
+{
+    Console.WriteLine("The file you have input does not exist");
+    return;
+}
+
+Console.WriteLine($"Please wait while {args[0]} is being unpacked...");
+(ICanvasDocument msapp, IEnumerable<IError> errors) = Utility.TryOperation(() => CanvasDocument.LoadFromMsapp(msAppPath));
+Console.Clear();
+
+if (ReportErrors(errors)) return;
+
+Repl<ICanvasDocument>.Start(new ReplMenu(), msapp);
+
+// Reports errors from unpack operation to console
+static bool ReportErrors(IEnumerable<IError> enumerable)
+{
+    var errorsArray = enumerable.ToArray();
+    if (errorsArray.Any())
+    {
+        Console.WriteLine($"{errorsArray.Count()} errors encountered:");
+        for (var i = 0; i < errorsArray.Length; i++)
+        {
+            Console.WriteLine($"{i}:  {errorsArray[i]}");
+        }
+
+        return true;
+    }
+
+    return false;
+}

--- a/src/Backdoor/Properties/AssemblyInfo.cs
+++ b/src/Backdoor/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Backdoor")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Backdoor")]
+[assembly: AssemblyCopyright("Copyright ©  2022")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("90CFC486-A80D-4668-8C00-BB6EDEF9EF36")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Backdoor/Repl/Functions/Delete.cs
+++ b/src/Backdoor/Repl/Functions/Delete.cs
@@ -11,10 +11,8 @@ namespace Backdoor.Repl.Functions
     public class Delete : IFunction<ICanvasDocument>
     {
         public string Name => "delete";
-        public bool TryDo(ICanvasDocument thing, IEnumerable<string> args, out string result, out IEnumerable<IError> errors)
+        public IResult<ICanvasDocument> Invoke(ICanvasDocument thing, IEnumerable<string> args)
         {
-            result = default(string);
-
             // To avoid errors, we validate the input before mutating the document
             var errorsList = new List<IError>();
             foreach (var arg in args)
@@ -27,8 +25,7 @@ namespace Backdoor.Repl.Functions
 
             if (errorsList.Any())
             {
-                errors = errorsList;
-                return false;
+                return new ResultState<ICanvasDocument>(thing, errorsList);
             }
 
             foreach (var arg in args)
@@ -41,8 +38,7 @@ namespace Backdoor.Repl.Functions
                 }
             }
 
-            errors = errorsList;
-            return true;
+            return new ResultState<ICanvasDocument>(thing, errorsList);
         }
     }
 }

--- a/src/Backdoor/Repl/Functions/Delete.cs
+++ b/src/Backdoor/Repl/Functions/Delete.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.PowerPlatform.Formulas.Tools;
+using Microsoft.PowerPlatform.Formulas.Tools.PAConvert;
+
+namespace Backdoor.Repl.Functions
+{
+    public class Delete : IFunction<ICanvasDocument>
+    {
+        public string Name => "delete";
+        public bool TryDo(ICanvasDocument thing, IEnumerable<string> args, out string result, out IEnumerable<IError> errors)
+        {
+            result = default(string);
+
+            // To avoid errors, we validate the input before mutating the document
+            var errorsList = new List<IError>();
+            foreach (var arg in args)
+            {
+                if (!thing.Exists(arg))
+                {
+                    errorsList.Add(new BackdoorError(true, false, $"{arg} does not exist"));
+                }
+            }
+
+            if (errorsList.Any())
+            {
+                errors = errorsList;
+                return false;
+            }
+
+            foreach (var arg in args)
+            {
+                if (!thing.TryRemoveControl(arg, out var deleteErrors))
+                {
+                    errorsList.Add(new BackdoorError(false, true, $"Control {arg} was located but could not be removed."));
+                    if (deleteErrors != null && deleteErrors.Any())
+                        errorsList.AddRange(deleteErrors);
+                }
+            }
+
+            errors = errorsList;
+            return true;
+        }
+    }
+}

--- a/src/Backdoor/Repl/Functions/Exit.cs
+++ b/src/Backdoor/Repl/Functions/Exit.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.PowerPlatform.Formulas.Tools;
+using Microsoft.PowerPlatform.Formulas.Tools.PAConvert;
+
+namespace Backdoor.Repl.Functions
+{
+    public class Exit : IFunction<ICanvasDocument>
+    {
+        public string Name => "exit";
+        public bool TryDo(ICanvasDocument thing, IEnumerable<string> args, out string result, out IEnumerable<IError> errors)
+        {
+            Environment.Exit(0);
+            result = default(string);
+            errors = default(IEnumerable<IError>);
+            return true;
+        }
+    }
+}

--- a/src/Backdoor/Repl/Functions/Exit.cs
+++ b/src/Backdoor/Repl/Functions/Exit.cs
@@ -11,12 +11,10 @@ namespace Backdoor.Repl.Functions
     public class Exit : IFunction<ICanvasDocument>
     {
         public string Name => "exit";
-        public bool TryDo(ICanvasDocument thing, IEnumerable<string> args, out string result, out IEnumerable<IError> errors)
+        public IResult<ICanvasDocument> Invoke(ICanvasDocument thing, IEnumerable<string> args)
         {
             Environment.Exit(0);
-            result = default(string);
-            errors = default(IEnumerable<IError>);
-            return true;
+            return new ResultState<ICanvasDocument>(thing);
         }
     }
 }

--- a/src/Backdoor/Repl/Functions/IFunction.cs
+++ b/src/Backdoor/Repl/Functions/IFunction.cs
@@ -2,13 +2,13 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
-using Microsoft.PowerPlatform.Formulas.Tools.PAConvert;
+using Microsoft.PowerPlatform.Formulas.Tools;
 
 namespace Backdoor.Repl.Functions
 {
     public interface IFunction<T>
     {
         public string Name { get; }
-        public bool TryDo(T thing, IEnumerable<string> args, out string result, out IEnumerable<IError> errors);
+        public IResult<ICanvasDocument> Invoke(T thing, IEnumerable<string> args);
     }
 }

--- a/src/Backdoor/Repl/Functions/IFunction.cs
+++ b/src/Backdoor/Repl/Functions/IFunction.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.PowerPlatform.Formulas.Tools.PAConvert;
+
+namespace Backdoor.Repl.Functions
+{
+    public interface IFunction<T>
+    {
+        public string Name { get; }
+        public bool TryDo(T thing, IEnumerable<string> args, out string result, out IEnumerable<IError> errors);
+    }
+}

--- a/src/Backdoor/Repl/Functions/ListControls.cs
+++ b/src/Backdoor/Repl/Functions/ListControls.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Backdoor.Repl.Functions.ListFunctions;
+using Microsoft.PowerPlatform.Formulas.Tools;
+using Microsoft.PowerPlatform.Formulas.Tools.PAConvert;
+
+namespace Backdoor.Repl.Functions
+{
+    public class ListControls : IFunction<ICanvasDocument>
+    {
+        public string Name => "list";
+
+        public delegate string ListFunction(ICanvasDocument document, IEnumerable<string> args, out IEnumerable<IError> errors);
+
+        private IEnumerable<IFunction<ICanvasDocument>> _listFunctions = new List<IFunction<ICanvasDocument>>()
+        {
+            new ListScreens(),
+            new ListChildren(),
+        };
+
+        public bool TryDo(ICanvasDocument thing, IEnumerable<string> args, out string result, out IEnumerable<IError> errors)
+        {
+            var argsList = args.ToList();
+            var errorsList = new List<IError>();
+            if (argsList.Count() < 1)
+            {
+                errorsList.Add(new BackdoorError(true, true, "Incorrect number of arguments."));
+                errors = errorsList;
+                result = default(string);
+                return false;
+            }
+
+            // The valid list functions are themselves functions that are named for the second argument of list
+            // and accept as arguments all arguments after the second argument provided to list.
+            // E.g. The function for `list children test` is 'children' which accepts 'test' as an argument.
+            var type = argsList.First();
+            var function = _listFunctions.FirstOrDefault(function => function.Name == type);
+            if (function == default(IFunction<ICanvasDocument>))
+            {
+                errorsList.Add(new BackdoorError(true, true, "Invalid argument"));
+                errors = errorsList;
+                result = default(string);
+                return false;
+            }
+
+            var success = function.TryDo(thing, argsList.Skip(1), out result, out var functionErrors);
+            if (functionErrors != null && functionErrors.Any())
+                errorsList.AddRange(functionErrors);
+
+            errors = errorsList;
+            return success;
+        }
+    }
+}

--- a/src/Backdoor/Repl/Functions/ListFunctions/ListChildren.cs
+++ b/src/Backdoor/Repl/Functions/ListFunctions/ListChildren.cs
@@ -12,7 +12,7 @@ namespace Backdoor.Repl.Functions.ListFunctions
     public class ListChildren : IFunction<ICanvasDocument>
     {
         public string Name => "children";
-        public bool TryDo(ICanvasDocument thing, IEnumerable<string> args, out string result, out IEnumerable<IError> errors)
+        public IResult<ICanvasDocument> Invoke(ICanvasDocument thing, IEnumerable<string> args)
         {
             var argsList = args.ToList();
             var errorsList = new List<IError>();
@@ -20,22 +20,17 @@ namespace Backdoor.Repl.Functions.ListFunctions
             if (parent == default(string))
             {
                 errorsList.Add(new BackdoorError(true, false, "No arguments provided"));
-                errors = errorsList;
-                result = default(string);
-                return false;
+                return new ResultState<ICanvasDocument>(thing, errorsList);
             }
 
             if (!thing.Exists(parent))
             {
                 errorsList.Add(new BackdoorError(true, false, $"{parent} does not exist"));
-                errors = errorsList;
-                result = default(string);
-                return false;
+                return new ResultState<ICanvasDocument>(thing, errorsList);
             }
 
-            errors = errorsList;
-            result = String.Join("\n", thing.GetChildren(parent));
-            return true;
+            var message = String.Join("\n", thing.GetChildren(parent));
+            return new ResultState<ICanvasDocument>(thing, errorsList, message);
         }
     }
 }

--- a/src/Backdoor/Repl/Functions/ListFunctions/ListChildren.cs
+++ b/src/Backdoor/Repl/Functions/ListFunctions/ListChildren.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.PowerPlatform.Formulas.Tools;
+using Microsoft.PowerPlatform.Formulas.Tools.PAConvert;
+
+namespace Backdoor.Repl.Functions.ListFunctions
+{
+    public class ListChildren : IFunction<ICanvasDocument>
+    {
+        public string Name => "children";
+        public bool TryDo(ICanvasDocument thing, IEnumerable<string> args, out string result, out IEnumerable<IError> errors)
+        {
+            var argsList = args.ToList();
+            var errorsList = new List<IError>();
+            var parent = argsList.FirstOrDefault();
+            if (parent == default(string))
+            {
+                errorsList.Add(new BackdoorError(true, false, "No arguments provided"));
+                errors = errorsList;
+                result = default(string);
+                return false;
+            }
+
+            if (!thing.Exists(parent))
+            {
+                errorsList.Add(new BackdoorError(true, false, $"{parent} does not exist"));
+                errors = errorsList;
+                result = default(string);
+                return false;
+            }
+
+            errors = errorsList;
+            result = String.Join("\n", thing.GetChildren(parent));
+            return true;
+        }
+    }
+}

--- a/src/Backdoor/Repl/Functions/ListFunctions/ListScreens.cs
+++ b/src/Backdoor/Repl/Functions/ListFunctions/ListScreens.cs
@@ -4,18 +4,13 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.PowerPlatform.Formulas.Tools;
-using Microsoft.PowerPlatform.Formulas.Tools.PAConvert;
 
 namespace Backdoor.Repl.Functions.ListFunctions
 {
     public class ListScreens : IFunction<ICanvasDocument>
     {
         public string Name => "screens";
-        public bool TryDo(ICanvasDocument thing, IEnumerable<string> args, out string result, out IEnumerable<IError> errors)
-        {
-            errors = default(IEnumerable<IError>);
-            result = String.Join("\n", thing.Screens);
-            return true;
-        }
+        public IResult<ICanvasDocument> Invoke(ICanvasDocument thing, IEnumerable<string> args) =>
+            new ResultState<ICanvasDocument>(thing, null, String.Join("\n", thing.Screens));
     }
 }

--- a/src/Backdoor/Repl/Functions/ListFunctions/ListScreens.cs
+++ b/src/Backdoor/Repl/Functions/ListFunctions/ListScreens.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.PowerPlatform.Formulas.Tools;
+using Microsoft.PowerPlatform.Formulas.Tools.PAConvert;
+
+namespace Backdoor.Repl.Functions.ListFunctions
+{
+    public class ListScreens : IFunction<ICanvasDocument>
+    {
+        public string Name => "screens";
+        public bool TryDo(ICanvasDocument thing, IEnumerable<string> args, out string result, out IEnumerable<IError> errors)
+        {
+            errors = default(IEnumerable<IError>);
+            result = String.Join("\n", thing.Screens);
+            return true;
+        }
+    }
+}

--- a/src/Backdoor/Repl/Functions/Open.cs
+++ b/src/Backdoor/Repl/Functions/Open.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Backdoor.Util;
+using Microsoft.PowerPlatform.Formulas.Tools;
+using Microsoft.PowerPlatform.Formulas.Tools.PAConvert;
+
+namespace Backdoor.Repl.Functions
+{
+    public class Open : IFunction<ICanvasDocument>
+    {
+        public string Name => "open";
+        public IResult<ICanvasDocument> Invoke(ICanvasDocument thing, IEnumerable<string> args)
+        {
+            var location = args.FirstOrDefault();
+            if (location == default(string))
+            {
+                return new ResultState<ICanvasDocument>(thing, new List<IError>()
+                {
+                    new BackdoorError(true, false, "No arguments!")
+                });
+            }
+
+            var path = Path.GetFullPath(location);
+            if (File.Exists(path))
+            {
+                (var msApp, var loadErrors) = Utility.TryOperation(() => CanvasDocument.LoadFromMsapp(path));
+                return new ResultState<ICanvasDocument>(msApp, loadErrors, $"Successfully opened {location}");
+            }
+            else if (Directory.Exists(path))
+            {
+                (var msApp, var loadErrors) = Utility.TryOperation(() => CanvasDocument.LoadFromSources(path));
+                return new ResultState<ICanvasDocument>(msApp, loadErrors, $"Successfully opened {location}");
+            }
+
+            return new ResultState<ICanvasDocument>(thing, new List<IError>()
+            {
+                new BackdoorError(true, false, $"{path} doesn't exist!")
+            });
+        }
+    }
+}

--- a/src/Backdoor/Repl/Functions/Pack.cs
+++ b/src/Backdoor/Repl/Functions/Pack.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.PowerPlatform.Formulas.Tools;
+using Microsoft.PowerPlatform.Formulas.Tools.PAConvert;
+
+namespace Backdoor.Repl.Functions
+{
+    public class Pack : SaveToFileFunction
+    {
+        public override string Name => "pack";
+        public override IEnumerable<IError> SaveToFile(ICanvasDocument document, string fullPathToMsApp) => document.SaveToFile(fullPathToMsApp);
+    }
+}

--- a/src/Backdoor/Repl/Functions/Result/Result.cs
+++ b/src/Backdoor/Repl/Functions/Result/Result.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Backdoor.Repl.Menus;
+using Microsoft.PowerPlatform.Formulas.Tools.PAConvert;
+
+namespace Backdoor.Repl.Functions
+{
+    public interface IResult<T>
+    {
+        public string Message { get; }
+        public IEnumerable<IError> Errors { get; }
+        public T Context { get; }
+    }
+
+    public class ResultState<T> : IResult<T>
+    {
+        public ResultState(T context, IEnumerable<IError> errors = default(IEnumerable<IError>), string message = default(string))
+        {
+            Message = message;
+            Errors = errors;
+            Context = context;
+        }
+
+        public string Message { get; }
+        public IEnumerable<IError> Errors { get; }
+        public T Context { get; }
+    }
+
+    public interface IMenuResultState<T> : IResult<T>
+    {
+        public IMenu<T> Menu { get; }
+    }
+
+    public class MenuResultState<T> : ResultState<T>, IMenuResultState<T>
+    {
+        public static IMenuResultState<T> FromResultState(IResult<T> result, IMenu<T> menu) =>
+            new MenuResultState<T>(menu, result.Context, result.Errors, result.Message);
+
+        public IMenu<T> Menu { get; }
+
+        public MenuResultState(IMenu<T> menu, T context, IEnumerable<IError> errors = default(IEnumerable<IError>), string message = default(string))
+            : base(context, errors, message)
+        {
+            Menu = menu;
+        }
+    }
+}

--- a/src/Backdoor/Repl/Functions/SaveToFileFunction.cs
+++ b/src/Backdoor/Repl/Functions/SaveToFileFunction.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Backdoor.Util;
+using Microsoft.PowerPlatform.Formulas.Tools;
+using Microsoft.PowerPlatform.Formulas.Tools.PAConvert;
+
+namespace Backdoor.Repl.Functions
+{
+    public abstract class SaveToFileFunction : IFunction<ICanvasDocument>
+    {
+        public abstract IEnumerable<IError> SaveToFile(ICanvasDocument document, string fullPathToMsApp);
+
+        public abstract string Name { get; }
+
+        public bool TryDo(ICanvasDocument thing, IEnumerable<string> args, out string result, out IEnumerable<IError> errors)
+        {
+            var errorsList = new List<IError>();
+            var argsList = args.ToList();
+            if (argsList.Count() == 0)
+            {
+                errorsList.Add(new BackdoorError(true, false, "No arguments!"));
+                errors = errorsList;
+
+                result = default(string);
+                return false;
+            }
+
+            var path =  Path.GetFullPath(argsList.First());
+            if (File.Exists(path))
+            {
+                errorsList.Add(new BackdoorError(true, false, $"{path} exists!"));
+                errors = errorsList;
+
+                result = default(string);
+                return false;
+            }
+
+            errors = Utility.TryOperation(() => SaveToFile(thing, path));
+            result = $"File saved at {path}";
+            return !errors.Any(error => error.IsError);
+        }
+    }
+}

--- a/src/Backdoor/Repl/Functions/SaveToFileFunction.cs
+++ b/src/Backdoor/Repl/Functions/SaveToFileFunction.cs
@@ -16,32 +16,29 @@ namespace Backdoor.Repl.Functions
 
         public abstract string Name { get; }
 
-        public bool TryDo(ICanvasDocument thing, IEnumerable<string> args, out string result, out IEnumerable<IError> errors)
+        public IResult<ICanvasDocument> Invoke(ICanvasDocument thing, IEnumerable<string> args)
         {
-            var errorsList = new List<IError>();
             var argsList = args.ToList();
             if (argsList.Count() == 0)
             {
-                errorsList.Add(new BackdoorError(true, false, "No arguments!"));
-                errors = errorsList;
-
-                result = default(string);
-                return false;
+                return new ResultState<ICanvasDocument>(thing, new List<IError>()
+                {
+                    new BackdoorError(true, false, "No arguments!")
+                });
             }
 
             var path =  Path.GetFullPath(argsList.First());
             if (File.Exists(path))
             {
-                errorsList.Add(new BackdoorError(true, false, $"{path} exists!"));
-                errors = errorsList;
-
-                result = default(string);
-                return false;
+                return new ResultState<ICanvasDocument>(thing, new List<IError>()
+                {
+                    new BackdoorError(true, false, $"{path} exists!")
+                });
             }
 
-            errors = Utility.TryOperation(() => SaveToFile(thing, path));
-            result = $"File saved at {path}";
-            return !errors.Any(error => error.IsError);
+            var errors = Utility.TryOperation(() => SaveToFile(thing, path));
+            var message = $"File saved at {path}";
+            return new ResultState<ICanvasDocument>(thing, errors, message);
         }
     }
 }

--- a/src/Backdoor/Repl/Functions/ToSource.cs
+++ b/src/Backdoor/Repl/Functions/ToSource.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.PowerPlatform.Formulas.Tools;
+using Microsoft.PowerPlatform.Formulas.Tools.PAConvert;
+
+namespace Backdoor.Repl.Functions
+{
+    public class ToSource : SaveToFileFunction
+    {
+        public override string Name => "source";
+        public override IEnumerable<IError> SaveToFile(ICanvasDocument document, string fullPathToMsApp) => document.SaveToSource(fullPathToMsApp);
+    }
+}

--- a/src/Backdoor/Repl/Menus/IMenu.cs
+++ b/src/Backdoor/Repl/Menus/IMenu.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
-using Microsoft.PowerPlatform.Formulas.Tools.PAConvert;
+using Backdoor.Repl.Functions;
 
 namespace Backdoor.Repl.Menus
 {
     public interface IMenu<T>
     {
-        public (IMenu<T>, string) TransferFunction(string input, T document, out IEnumerable<IError> errors);
+        public IMenuResultState<T> TransferFunction(string input, T document);
         public string Title { get; }
         public string Description { get; }
     }

--- a/src/Backdoor/Repl/Menus/IMenu.cs
+++ b/src/Backdoor/Repl/Menus/IMenu.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.PowerPlatform.Formulas.Tools.PAConvert;
+
+namespace Backdoor.Repl.Menus
+{
+    public interface IMenu<T>
+    {
+        public (IMenu<T>, string) TransferFunction(string input, T document, out IEnumerable<IError> errors);
+        public string Title { get; }
+        public string Description { get; }
+    }
+}

--- a/src/Backdoor/Repl/Menus/ReplMenu.cs
+++ b/src/Backdoor/Repl/Menus/ReplMenu.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Backdoor.Repl.Functions;
+using Microsoft.PowerPlatform.Formulas.Tools;
+using Microsoft.PowerPlatform.Formulas.Tools.PAConvert;
+
+namespace Backdoor.Repl.Menus
+{
+    public class ReplMenu : IMenu<ICanvasDocument>
+    {
+        public static IList<IFunction<ICanvasDocument>> FunctionLibrary { get; } = new List<IFunction<ICanvasDocument>>()
+        {
+            new Delete(),
+            new Pack(),
+            new ToSource(),
+            new ListControls(),
+            new Exit()
+        };
+
+        public (IMenu<ICanvasDocument>, string) TransferFunction(string input, ICanvasDocument document, out IEnumerable<IError> errors)
+        {
+            var tokens = Parser.Tokenize(input).ToArray();
+            var command = tokens.FirstOrDefault();
+            var errorsList = new List<IError>();
+            if (command == null)
+            {
+                errors = errorsList;
+                return (this, default(string));
+            }
+
+            var function = FunctionLibrary.FirstOrDefault(function =>
+            {
+                return function.Name == command;
+            });
+
+            if (function == null)
+            {
+                errorsList.Add(new BackdoorError(true, false, $"{command} is not a valid command."));
+                errors = errorsList;
+                return (this, default(string));
+            }
+
+            if (!function.TryDo(document, tokens.Skip(1), out var result, out var functionErrors))
+            {
+                errorsList.Add(new BackdoorError(true, false, $"Command {function.Name} failed."));
+                errorsList.AddRange(functionErrors);
+            }
+
+            errors = errorsList;
+            return (this, result);
+        }
+
+        public string Title => "";
+        public string Description =>  "> ";
+    }
+}

--- a/src/Backdoor/Repl/Parser.cs
+++ b/src/Backdoor/Repl/Parser.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+
+namespace Backdoor.Repl
+{
+    public class Parser
+    {
+        public static IEnumerable<string> Tokenize(string input)
+        {
+            var start = 0;
+            var end = 0;
+            var tokens = new List<string>();
+            var inQuotes = false;
+            for (var i = 0; i < input.Length; i++)
+            {
+                var character = input[i];
+                switch (character)
+                {
+                    case ' ':
+                        if (inQuotes)
+                        {
+                            end += 1;
+                            break;
+                        }
+
+                        if (TryGetToken(start, end, input, out string token))
+                        {
+                            tokens.Add(token);
+                        }
+                        start = end = i + 1;
+                        break;
+
+                    case '"':
+                        inQuotes = !inQuotes;
+                        end += 1;
+                        break;
+                    default:
+                        end += 1;
+                        break;
+                }
+            }
+
+            if (TryGetToken(start, end, input, out string finalToken))
+            {
+                tokens.Add(finalToken);
+            }
+
+            return tokens;
+        }
+
+        private static bool TryGetToken(int start, int end, string input, out string s)
+        {
+            if (start < 0 || end < 0 || end <= start || end > input.Length)
+            {
+                s = default(string);
+                return false;
+            }
+
+            s = input.Substring(start, end - start);
+            return true;
+        }
+    }
+}

--- a/src/Backdoor/Repl/Repl.cs
+++ b/src/Backdoor/Repl/Repl.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using Backdoor.Repl.Menus;
+using Microsoft.PowerPlatform.Formulas.Tools.PAConvert;
 
 namespace Backdoor.Repl
 {
@@ -18,15 +20,20 @@ namespace Backdoor.Repl
                 try
                 {
                     var input = Console.ReadLine();
-                    string output;
-                    (current, output) = current.TransferFunction(input, subject, out var errors);
-                    foreach (var error in errors)
+                    var result = current.TransferFunction(input, subject);
+
+                    if (result.Errors != default(IEnumerable<IError>))
                     {
-                        Console.WriteLine($"Error:  {error}");
+                        foreach (var error in result.Errors)
+                        {
+                            Console.WriteLine($"Error:  {error}");
+                        }
                     }
 
-                    if (output != default(string))
-                        Console.WriteLine($"\n{output}");
+                    if (result.Message != default(string))
+                        Console.WriteLine($"\n{result.Message}");
+
+                    subject = result.Context;
                 }
                 catch (Exception e) {
                     Console.WriteLine(e);

--- a/src/Backdoor/Repl/Repl.cs
+++ b/src/Backdoor/Repl/Repl.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Backdoor.Repl.Menus;
+
+namespace Backdoor.Repl
+{
+    public class Repl<T>
+    {
+        public static void Start(IMenu<T> mainMenu, T subject)
+        {
+            var current = mainMenu;
+
+            while (true) {
+                Console.WriteLine(current.Title);
+                Console.Write(current.Description);
+                try
+                {
+                    var input = Console.ReadLine();
+                    string output;
+                    (current, output) = current.TransferFunction(input, subject, out var errors);
+                    foreach (var error in errors)
+                    {
+                        Console.WriteLine($"Error:  {error}");
+                    }
+
+                    if (output != default(string))
+                        Console.WriteLine($"\n{output}");
+                }
+                catch (Exception e) {
+                    Console.WriteLine(e);
+                }
+            }
+        }
+    }
+}

--- a/src/Backdoor/Util/Utility.cs
+++ b/src/Backdoor/Util/Utility.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.PowerPlatform.Formulas.Tools;
+using Microsoft.PowerPlatform.Formulas.Tools.PAConvert;
+
+namespace Backdoor.Util
+{
+    public class Utility
+    {
+        public static (ICanvasDocument, IEnumerable<IError>) TryOperation(Func<(ICanvasDocument, IEnumerable<IError>)> operation)
+        {
+            try
+            {
+                return operation();
+            }
+            catch (Exception e)
+            {
+                // Add unhandled exception to the error container.
+                return (null, new []{ new BackdoorError(true, false, $"Internal error. {e.Message}\r\nStack Trace:\r\n{e.StackTrace}") });
+            }
+        }
+
+        public static IEnumerable<IError> TryOperation(Func<IEnumerable<IError>> operation)
+        {
+            try
+            {
+                return operation();
+            }
+            catch (Exception e)
+            {
+                // Add unhandled exception to the error container.
+                return new []{ new BackdoorError(true, false, $"Internal error. {e.Message}\r\nStack Trace:\r\n{e.StackTrace}") };
+            }
+        }
+    }
+}

--- a/src/PAModel/ICanvasDocument.cs
+++ b/src/PAModel/ICanvasDocument.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.PowerPlatform.Formulas.Tools.PAConvert;
+
+namespace Microsoft.PowerPlatform.Formulas.Tools
+{
+    public interface ICanvasDocument
+    {
+        public bool TryRemoveControl(string controlName, out IEnumerable<IError> errors);
+        public bool Exists(string controlName);
+        public IEnumerable<string> GetChildren(string controlName);
+        public IEnumerable<IError> SaveToFile(string fullPathToMsApp);
+        public IEnumerable<IError> SaveToSource(string pathToSourceDirectory);
+        public IEnumerable<string> Screens { get; }
+    }
+}

--- a/src/PAModel/IR/DeleteVisitor.cs
+++ b/src/PAModel/IR/DeleteVisitor.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.PowerPlatform.Formulas.Tools.IR
+{
+    internal class DeleteVisitor : DefaultVisitor<DeleteVisitorContext>
+    {
+        public ErrorContainer Errors { get; } = new ErrorContainer();
+        private Action<BlockNode> CreateDeleteNode(BlockNode node)
+        {
+            return nodeToDelete =>
+            {
+                if (node.Children.Contains(nodeToDelete))
+                {
+                    node.Children.Remove(nodeToDelete);
+                }
+                else
+                {
+                    Errors.AddError(ErrorCode.Generic, SourceLocation.FromFile(""), $"Node {nodeToDelete.Name.Identifier} located but could not be deleted.");
+                }
+            };
+        }
+
+        public override void Visit(BlockNode node, DeleteVisitorContext context)
+        {
+            if (node.Name.Identifier == context.NameToDelete)
+            {
+                context.DeleteNode(node);
+                context.DidDelete = true;
+                return;
+            }
+
+            foreach (var child in node.Children)
+            {
+                context.DeleteNode = CreateDeleteNode(node);
+                child.Accept(this, context);
+                if (context.DidDelete)
+                    return;
+            }
+        }
+    }
+}

--- a/src/PAModel/IR/DeleteVisitorContext.cs
+++ b/src/PAModel/IR/DeleteVisitorContext.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.PowerPlatform.Formulas.Tools.IR
+{
+    internal class DeleteVisitorContext
+    {
+        public DeleteVisitorContext(string nameToDelete, Action<BlockNode> deleteNode)
+        {
+            NameToDelete = nameToDelete;
+            DeleteNode = deleteNode;
+        }
+
+        public Action<BlockNode> DeleteNode { get; set; }
+        public string NameToDelete { get; }
+        public bool DidDelete { get; set; }
+    }
+}

--- a/src/PAModel/IR/IRNode.cs
+++ b/src/PAModel/IR/IRNode.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
 
 namespace Microsoft.PowerPlatform.Formulas.Tools.IR
 {

--- a/src/PAModel/IR/IRNodeVisitor.cs
+++ b/src/PAModel/IR/IRNodeVisitor.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.PowerPlatform.Formulas.Tools.IR
 {

--- a/src/PAModel/PAConvert/Error.cs
+++ b/src/PAModel/PAConvert/Error.cs
@@ -4,13 +4,14 @@
 using Microsoft.PowerPlatform.Formulas.Tools.IR;
 using System.Runtime.CompilerServices;
 using System.Text;
+using Microsoft.PowerPlatform.Formulas.Tools.PAConvert;
 
 namespace Microsoft.PowerPlatform.Formulas.Tools
 {
     /// <summary>
-    /// An Error or warning encountered while doing a source operation. 
+    /// An Error or warning encountered while doing a source operation.
     /// </summary>
-    public class Error
+    public class Error : IError
     {
         internal ErrorCode Code;
         internal SourceLocation Span;

--- a/src/PAModel/PAConvert/ErrorContainer.cs
+++ b/src/PAModel/PAConvert/ErrorContainer.cs
@@ -7,6 +7,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.PowerPlatform.Formulas.Tools.PAConvert;
 
 namespace Microsoft.PowerPlatform.Formulas.Tools
 {
@@ -17,16 +18,16 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
     public class ErrorContainer : IEnumerable<Error>
     {
         private List<Error> _errors = new List<Error>();
-                
+
         internal void AddError(ErrorCode code, SourceLocation span, string errorMessage)
         {
             _errors.Add(new Error(code, span, errorMessage));
-        }        
+        }
 
         public bool HasErrors => _errors.Any(error => error.IsError);
 
         // Helper for interupting processing once we have errors.
-        // Ignores warnings. 
+        // Ignores warnings.
         internal void ThrowOnErrors()
         {
             if (this.HasErrors)

--- a/src/PAModel/PAConvert/IError.cs
+++ b/src/PAModel/PAConvert/IError.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.PowerPlatform.Formulas.Tools.PAConvert
+{
+    public interface IError
+    {
+        public bool IsError { get; }
+        public bool IsWarning { get; }
+    }
+}

--- a/src/PAModel/Utility/ICloneable.cs
+++ b/src/PAModel/Utility/ICloneable.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Microsoft.PowerPlatform.Formulas.Tools.Utility
 {
-    internal interface ICloneable<T>
+    public interface ICloneable<T>
     {
         T Clone();
     }

--- a/src/PASopa.sln
+++ b/src/PASopa.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PAModelTests", "PAModelTest
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{4993E606-484B-46D9-892E-7AE9CE8D4423}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Backdoor", "Backdoor\Backdoor.csproj", "{90CFC486-A80D-4668-8C00-BB6EDEF9EF36}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,6 +31,10 @@ Global
 		{8AD94CC0-7330-4880-A8E0-177B37CDB27B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8AD94CC0-7330-4880-A8E0-177B37CDB27B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8AD94CC0-7330-4880-A8E0-177B37CDB27B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{90CFC486-A80D-4668-8C00-BB6EDEF9EF36}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{90CFC486-A80D-4668-8C00-BB6EDEF9EF36}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{90CFC486-A80D-4668-8C00-BB6EDEF9EF36}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{90CFC486-A80D-4668-8C00-BB6EDEF9EF36}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/PASopa/Program.cs
+++ b/src/PASopa/Program.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Microsoft.PowerPlatform.Formulas.Tools;
-using Microsoft.PowerPlatform.Formulas.Tools.MergeTool;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -52,12 +51,12 @@ namespace PASopa
                 string msAppCommon = Path.Combine(msAppPathDir, "empty.msapp");
                 foreach (var msAppPath in Directory.EnumerateFiles(msAppPathDir, "*.msapp", SearchOption.TopDirectoryOnly))
                 {
-                    // Merge test requires a 2nd app. Could do a full NxN matrix. But here, just pick the first item. 
+                    // Merge test requires a 2nd app. Could do a full NxN matrix. But here, just pick the first item.
                     msAppCommon ??= msAppPath;
 
                     Stopwatch sw = Stopwatch.StartNew();
                     bool ok = MsAppTest.MergeStressTest(msAppCommon, msAppPath);
-                    
+
                     var str = ok ? "Pass" : "FAIL";
                     countTotal++;
                     if (ok) { countPass++; }
@@ -145,7 +144,7 @@ namespace PASopa
                 if (errors.HasErrors)
                 {
                     return;
-                }                
+                }
             }
             else if (mode == "-pack")
             {


### PR DESCRIPTION
Disclaimer:  I realize this update is unprompted and written without team permission, so note that I don't intend to merge it with an sense of expediency.  I am open to any suggestions the team may have.

I needed to procedurally delete screens in order to triage a bug I am investigating.

To do this, I create a basic PASopa REPL that I've called Backdoor (working title).  It unpacks the first argument and starts a REPL for which I implemented a few commands.

`list children control_name` 
Lists all children of `control_name` if it exists

`list screens`
Lists all screens of the application

`delete control_name`
Deletes `control_name` if it exists

`pack location`
Packs current application to provided location

`exit`
Exits the REPL


I originally implemented a menu-based command line, hence the existence of IMenu<T>.  The purpose of this was to provide different functionality depending on user input.

IMenu implements a description, which is emitted to console when the menu is active.  There can only be one active menu at any given time.  A menu implements a transfer function which will evaluate an input and return the next menu.  The transfer function accepts an input and an instance of T as an argument.  It produces a string result and may populate a collection of errors, both of which are displayed to the screen when the input is evaluated.

The ReplMenu is the only menu in this PR.  It will call one of the aforementioned functions depending on the input (e.g. if `list screen` is input, it will invoke the ListControls function.

A function may be called on user input.  A function implements a name so that its implementation may be fetched if the user inputs its name.  A function also implements a method TryDo that bears the implementation of a function.  TryDo accepts a list of arguments that a menu may pass to it on which the function may depend.  It produces a string result and may also populate a collection of errors.

Functions are designed in a telescopic way.  For instance, ListControls bears a list of functions that can be used depending on the second and subsequent arguments.  However, fi they were fed the full list of arguments straight away, they would fail.