### PR TITLE
Handling teststep invalid screen reference by assigning it null

### DIFF
--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -190,10 +190,10 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
                 {
                     foreach (var pair in _screenIdToScreenName.ToDictionary(kvp => kvp.Value, kvp => kvp.Key))
                     {
-                        // in roundtrip scenario screen name could be assigned null so to avoid null key in dictionary need this check 
-                        if (pair.Value != null && pair.Value.Equals(screenProp.Expression.Expression))
+                        // in roundtrip scenario pair could have null Key and need this check 
+                        if (pair.Value != null && pair.Key.Equals(screenProp.Expression.Expression))
                         {
-                            screenId = pair.Key;
+                            screenId = pair.Value;
                         }
                     }
                     if (screenId == null)

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -190,7 +190,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
                 {
                     foreach (var pair in _screenIdToScreenName.ToDictionary(kvp => kvp.Value, kvp => kvp.Key))
                     {
-                        // in roundtrip scenario pair could have null Key and need this check 
+                        // in roundtrip scenario pair could have null value and need this check 
                         if (pair.Value != null && pair.Key.Equals(screenProp.Expression.Expression))
                         {
                             screenId = pair.Value;


### PR DESCRIPTION
Problem: With the new change to assign invalid screenname as null, dictionary with null key exception possible while reading it in beforeWrite()
Solution: handling cases when dictionary key is null, then avoiding this exception in ApptestTransform beforeWrite()

Validation: Roundtrips all test .msapps in test battery and in this repo without errors. Roundtrips validation successful for customer .msapp with this inconsistency.