### PR TITLE
Handling Null ref with ScreenId

### DIFF
--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -188,7 +188,13 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
                 // Lookup screenID by Name
                 if (screenProp != null)
                 {
-                    _screenIdToScreenName.ToDictionary(kvp => kvp.Value, kvp => kvp.Key).TryGetValue(screenProp.Expression.Expression, out screenId);
+                    foreach (var prop in _screenIdToScreenName.ToDictionary(kvp => kvp.Value, kvp => kvp.Key))
+                    {
+                        if (prop.Key != null && prop.Key == screenProp.Expression.Expression)
+                        {
+                            screenId = prop.Value;
+                        }
+                    }
 
                     // in roundtrip scenario screenId could be null
                     if (screenId == null)

--- a/src/PAModel/SourceTransforms/AppTestTransform.cs
+++ b/src/PAModel/SourceTransforms/AppTestTransform.cs
@@ -188,11 +188,11 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms
                 // Lookup screenID by Name
                 if (screenProp != null)
                 {
-                    foreach (var prop in _screenIdToScreenName.ToDictionary(kvp => kvp.Value, kvp => kvp.Key))
+                    foreach (var prop in _screenIdToScreenName)
                     {
-                        if (prop.Key != null && prop.Key == screenProp.Expression.Expression)
+                        if (prop.Value != null && prop.Value == screenProp.Expression.Expression)
                         {
-                            screenId = prop.Value;
+                            screenId = prop.Key;
                         }
                     }
 

--- a/src/PAModelTests/RoundtripTests.cs
+++ b/src/PAModelTests/RoundtripTests.cs
@@ -13,37 +13,21 @@ namespace PAModelTests
     public class RoundtripTests
     {
         // Apps live in the "Apps" folder, and should have a build action of "Copy to output"
-        [DataTestMethod]
-        [DataRow("MyWeather.msapp")]
-        [DataRow("Chess_for_Power_Apps_v1.03.msapp")]
-        [DataRow("AppWithLabel.msapp")]
-        [DataRow("GalleryTestApp.msapp")]
-        [DataRow("AccountPlanReviewerMaster.msapp")]
-        [DataRow("Marc2PowerPlatformDevOpsAlm.msapp")]
-        [DataRow("SimpleScopeVariables.msapp")]
-        [DataRow("WadlConnector.msapp")]
-        [DataRow("GroupControlTest.msapp")]
-        [DataRow("EmptyTestCase.msapp")]
-        [DataRow("ComponentTest.msapp")]
-        [DataRow("autolayouttest.msapp")]
-        [DataRow("TestStudio_Test.msapp")]
-        [DataRow("ComponentDefinitionWithAllowGlobalAccessProperty.msapp")]
-        [DataRow("ComponentDefinitionWithoutAllowGlobalAccessProperty.msapp")]
-        [DataRow("DuplicateScreen.msapp")]
-        [DataRow("ComponentNameCollision.msapp")]
-        [DataRow("LocaleBasedApplication.msapp")]
-        public void StressTestApps(string filename)
+        [TestMethod]
+        public void StressTestApps()
         {
-            var root = Path.Combine(Environment.CurrentDirectory, "Apps", filename);
+            var directory = Path.Combine(Environment.CurrentDirectory, "Apps");
+            foreach (var root in Directory.GetFiles(directory))
+            { 
+                Assert.IsTrue(File.Exists(root));
 
-            Assert.IsTrue(File.Exists(root));
+                bool ok = MsAppTest.StressTest(root);
+                Assert.IsTrue(ok);
 
-            bool ok = MsAppTest.StressTest(root);
-            Assert.IsTrue(ok);
-
-            var cloneOk = MsAppTest.TestClone(root);
-            // If this fails, to debug it, rerun and set a breakpoint in DebugChecksum().
-            Assert.IsTrue(cloneOk, $"Clone failed: " + filename);
+                var cloneOk = MsAppTest.TestClone(root);
+                // If this fails, to debug it, rerun and set a breakpoint in DebugChecksum().
+                Assert.IsTrue(cloneOk, $"Clone failed: " + root);
+            }
         }
     }
 }

--- a/src/PAModelTests/RoundtripTests.cs
+++ b/src/PAModelTests/RoundtripTests.cs
@@ -17,16 +17,22 @@ namespace PAModelTests
         public void StressTestApps()
         {
             var directory = Path.Combine(Environment.CurrentDirectory, "Apps");
-            foreach (var root in Directory.GetFiles(directory))
-            { 
-                Assert.IsTrue(File.Exists(root));
+            try
+            {
+                foreach (var root in Directory.GetFiles(directory))
+                {
+                    Assert.IsTrue(File.Exists(root));
 
-                bool ok = MsAppTest.StressTest(root);
-                Assert.IsTrue(ok);
+                    bool ok = MsAppTest.StressTest(root);
+                    Assert.IsTrue(ok);
 
-                var cloneOk = MsAppTest.TestClone(root);
-                // If this fails, to debug it, rerun and set a breakpoint in DebugChecksum().
-                Assert.IsTrue(cloneOk, $"Clone failed: " + root);
+                    var cloneOk = MsAppTest.TestClone(root);
+                    // If this fails, to debug it, rerun and set a breakpoint in DebugChecksum().
+                    Assert.IsTrue(cloneOk, $"Clone failed: " + root);
+                }
+            }
+            catch (Exception ex) {
+                Assert.Fail(ex.ToString());
             }
         }
     }

--- a/src/PAModelTests/RoundtripTests.cs
+++ b/src/PAModelTests/RoundtripTests.cs
@@ -17,12 +17,11 @@ namespace PAModelTests
         public void StressTestApps()
         {
             var directory = Path.Combine(Environment.CurrentDirectory, "Apps");
-            try
+            
+            foreach (var root in Directory.GetFiles(directory))
             {
-                foreach (var root in Directory.GetFiles(directory))
+                try
                 {
-                    Assert.IsTrue(File.Exists(root));
-
                     bool ok = MsAppTest.StressTest(root);
                     Assert.IsTrue(ok);
 
@@ -30,10 +29,11 @@ namespace PAModelTests
                     // If this fails, to debug it, rerun and set a breakpoint in DebugChecksum().
                     Assert.IsTrue(cloneOk, $"Clone failed: " + root);
                 }
-            }
-            catch (Exception ex) {
-                Assert.Fail(ex.ToString());
-            }
+                catch (Exception ex)
+                {
+                    Assert.Fail(ex.ToString());
+                }
+            }            
         }
     }
 }


### PR DESCRIPTION
Resolving Null ref with ScreenId.
Also improving stresstest to include all test .msapps.

Validation: Roundtrips all test .msapps in test battery and in this repo without errors. 
 Roundtrips validation successful for customer .msapp with this inconsistency.