### PR TITLE
PALT PR Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,13 @@
 ## Type
 
-- [ ] Bug fix
-- [ ] Enhancement
-- [ ] Documentation
-- [ ] Fix breaking change
-- [ ] Testing/Error reporting
+Only keep relevant type. Delete the rest and this comment.
+
+- Bug fix
+- Git files
+- Enhancement
+- Documentation
+- Fix breaking change
+- Testing/Error reporting
 
 ## Problem
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,10 +3,10 @@
 Only keep relevant type. Delete the rest and this comment.
 
 - Bug fix
-- Git files
 - Enhancement
 - Documentation
 - Fix breaking change
+- Update to Git files
 - Testing/Error reporting
 
 ## Problem
@@ -22,3 +22,7 @@ What are we doing to solve this issue?
 - Log what was changed
 - Log what was changed
 - Log what was changed
+
+## Validation
+
+- How did you verify that this issue is truly fixed?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Type
 
-Only keep relevant type. Delete the rest and this comment.
+Only keep relevant type. Delete the rest and this comment. If this is related to an issue open in GitHub, please link it to this ticket and put the URL here.
 
 - Bug fix
 - Enhancement

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Type
+
+- [ ] Bug fix
+- [ ] Enhancement
+- [ ] Documentation
+- [ ] Fix breaking change
+- [ ] Testing/Error reporting
+
+## Problem
+
+What is the issue we are attempting to solve?
+
+## Solution
+
+What are we doing to solve this issue?
+
+## Changes
+
+- Log what was changed
+- Log what was changed
+- Log what was changed

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,4 @@
-## Type
-
-Only keep relevant type. Delete the rest and this comment. If this is related to an issue open in GitHub, please link it to this ticket and put the URL here.
-
-- Bug fix
-- Enhancement
-- Documentation
-- Fix breaking change
-- Update to Git files
-- Testing/Error reporting
+If this is related to an issue open in GitHub, please link it to this ticket and put the URL here.
 
 ## Problem
 


### PR DESCRIPTION
## Type

- Update to Git files

## Problem

There is no standardized form of PR documentation.

## Solution

Create a PR template, so that all future PR's will start with the same generic format.

## Changes

- Created a pull_request_template.md file (pr template)

## Validation

- Compared to other PR Templates
- Talked to other team members
