### PR TITLE
Making assembly version Up to date

### DIFF
--- a/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
+++ b/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
@@ -32,9 +32,9 @@
   </PropertyGroup>
 
   <Target Name="PALTVersion" AfterTargets="MinVer">
-   <PropertyGroup>
-    <AssemblyVersion>$(MinVer)</AssemblyVersion>
-   </PropertyGroup>
+    <PropertyGroup>
+      <AssemblyVersion>$(MinVer)</AssemblyVersion>
+    </PropertyGroup>
   </Target>
     
   <ItemGroup>

--- a/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
+++ b/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
@@ -31,7 +31,7 @@
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
   </PropertyGroup>
 
-  <Target Name="PALTVersion" AfterTargets="MinVer">
+  <Target Name="PALT" AfterTargets="MinVer">
     <PropertyGroup>
       <AssemblyVersion>$(MinVer)</AssemblyVersion>
     </PropertyGroup>

--- a/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
+++ b/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
@@ -31,6 +31,12 @@
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
   </PropertyGroup>
 
+  <Target Name="PALTVersion" AfterTargets="MinVer">
+   <PropertyGroup>
+    <AssemblyVersion>$(MinVer)</AssemblyVersion>
+   </PropertyGroup>
+  </Target>
+    
   <ItemGroup>
     <EmbeddedResource Include="ControlTemplates/commonStyleProperties.xml" />
     <EmbeddedResource Include="Themes/DefaultTheme.json" />


### PR DESCRIPTION
**Problem**: PALTVersion always showing as 0.0.0.0
**Solution**: Use the MinVer version (used for versioning in this repo) and set that as assemblyversion
**Validation**: Build and checked AssemblyInfo.cs generated, the version is updated
![image](https://user-images.githubusercontent.com/98551644/168921815-d5179f4f-e13c-433b-ab44-23dd8ef265ca.png)
