### PR TITLE
Additional logging & validation for arg.Default.Expression

### DIFF
--- a/src/PAModel/IR/IRStateHelpers.cs
+++ b/src/PAModel/IR/IRStateHelpers.cs
@@ -433,6 +433,13 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 var argKey = $"{controlName}.{propertyName}";
                 var defaultRule = entropy.GetDefaultScript(argKey, arg.Default.Expression);
 
+                //print structure of arg.Default.Expression using 'StructuralPrint'
+
+                // Check validity of arg.Default.Expression before letting program continue
+                // if(arg.Default.Expression)
+                // if(arg.Default.Expression)
+                // if(arg.Default.Expression)
+                
                 if (!scopeArgs.TryGetValue(propertyName, out var propScopeRule))
                 {
                     errors.ParseError(func.SourceSpan.GetValueOrDefault(), "Functions are not yet supported without corresponding custom properties in ControlTemplates.json");

--- a/src/PAModel/IR/IRStateHelpers.cs
+++ b/src/PAModel/IR/IRStateHelpers.cs
@@ -433,13 +433,13 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 var argKey = $"{controlName}.{propertyName}";
                 var defaultRule = entropy.GetDefaultScript(argKey, arg.Default.Expression);
 
-                //print structure of arg.Default.Expression using 'StructuralPrint'
+                // print structure of arg.Default.Expression using 'StructuralPrint'
 
                 // Check validity of arg.Default.Expression before letting program continue
                 // if(arg.Default.Expression)
                 // if(arg.Default.Expression)
                 // if(arg.Default.Expression)
-                
+
                 if (!scopeArgs.TryGetValue(propertyName, out var propScopeRule))
                 {
                     errors.ParseError(func.SourceSpan.GetValueOrDefault(), "Functions are not yet supported without corresponding custom properties in ControlTemplates.json");


### PR DESCRIPTION
## Problem
This roundtrip error is being thrown:
`PA3013: Property Value Changed: *.ScopeVariableInfo.DefaultRule`

This is most likely being caused by `arg.Default.Expression` being set to the wrong value in IRStateHelpers.cs : 434:
`var defaultRule = entropy.GetDefaultScript(argKey,arg.Default.Expression);`

And being set in IRStateHelper.cs : 447:
`propScopeRule.ScopeVariableInfo.DefaultRule = defaultRule;`


## Solution

- Log Default.Expression for every case for better visibility in the future
- Validate arg.Default.Expression in the future; need more if statements between lines 434 & 447 to catch currently unexpected behavior


## Changes

- Logging the structure of Default.Expression
- Validate Default.Expression, printing errors if containing unexpected behavior

## Validation

- Affirming with other developers that this is sufficient information for us to diagnose the real/underlying issue in the future.