### PR TITLE
Handling CanvasDocument.RestoreAssetFilePaths() exceptions 

### DIFF
--- a/src/PAModel/CanvasDocument.cs
+++ b/src/PAModel/CanvasDocument.cs
@@ -624,7 +624,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             if (_entropy.LocalResourceFileNames == null)
                 return;
 
-            if (_resourcesJson == null)
+            if (_resourcesJson == null || _assetFiles == null)
                 return;
 
             var maxFileNumber = FindMaxEntropyFileName();          
@@ -639,7 +639,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                     continue;
 
                 string msappFileName = "";
-                if (_entropy.LocalResourceFileNames != null && !_entropy.LocalResourceFileNames.TryGetValue(resource.Name, out msappFileName))
+                if (!_entropy.LocalResourceFileNames.TryGetValue(resource.Name, out msappFileName))
                 {
                     maxFileNumber++;
                     msappFileName = maxFileNumber.ToString("D4") + assetFilePath.GetExtension();

--- a/src/PAModel/CanvasDocument.cs
+++ b/src/PAModel/CanvasDocument.cs
@@ -638,7 +638,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 if (!_assetFiles.TryGetValue(assetFilePath, out var fileEntry))
                     continue;
 
-                string msappFileName;
+                string msappFileName = "";
                 if (!_entropy.LocalResourceFileNames.TryGetValue(resource.Name, out msappFileName))
                 {
                     maxFileNumber++;

--- a/src/PAModel/CanvasDocument.cs
+++ b/src/PAModel/CanvasDocument.cs
@@ -659,7 +659,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 var withoutPrefix = GetAssetFilePathWithoutPrefix(resource.Path);
                 fileEntry.Name = withoutPrefix;
                 _assetFiles.Remove(assetFilePath);
-                _assetFiles.Add(withoutPrefix, fileEntry);
+                _assetFiles[withoutPrefix] = fileEntry;
             }
         }
 

--- a/src/PAModel/CanvasDocument.cs
+++ b/src/PAModel/CanvasDocument.cs
@@ -638,7 +638,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 if (!_assetFiles.TryGetValue(assetFilePath, out var fileEntry))
                     continue;
 
-                string msappFileName = "";
+                string msappFileName;
                 if (!_entropy.LocalResourceFileNames.TryGetValue(resource.Name, out msappFileName))
                 {
                     maxFileNumber++;

--- a/src/PAModel/CanvasDocument.cs
+++ b/src/PAModel/CanvasDocument.cs
@@ -639,7 +639,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                     continue;
 
                 string msappFileName = "";
-                if (!_entropy.LocalResourceFileNames.TryGetValue(resource.Name, out msappFileName))
+                if (_entropy.LocalResourceFileNames != null && !_entropy.LocalResourceFileNames.TryGetValue(resource.Name, out msappFileName))
                 {
                     maxFileNumber++;
                     msappFileName = maxFileNumber.ToString("D4") + assetFilePath.GetExtension();

--- a/src/PAModelTests/WriteTransformTests.cs
+++ b/src/PAModelTests/WriteTransformTests.cs
@@ -28,5 +28,22 @@ namespace PAModelTests
             msapp.ApplyBeforeMsAppWriteTransforms(errors);
             Assert.IsFalse(errors.HasErrors);
         }
+
+        [DataTestMethod]
+        [DataRow("AccountPlanReviewerMaster.msapp")]
+        public void TestAssetFilesNullCase(string filename)
+        {
+            var root = Path.Combine(Environment.CurrentDirectory, "Apps", filename);
+            Assert.IsTrue(File.Exists(root));
+
+            (var msapp, var errors) = CanvasDocument.LoadFromMsapp(root);
+            errors.ThrowOnErrors();
+
+            // explicitly setting it to null
+            msapp._assetFiles = null;
+
+            msapp.ApplyBeforeMsAppWriteTransforms(errors);
+            Assert.IsFalse(errors.HasErrors);
+        }
     }
 }


### PR DESCRIPTION
## Problem
Null Reference and Argument Exceptions in RestoreAssetFilePaths()

## Solution
Resolving these exceptions by handling duplicate keys and null references

## Validation
Roundtrip validation on test .msapps and test battery
