### PR TITLE
Improving the missing closing quote error log with line details

### DIFF
--- a/src/PAModel/PAConvert/Parser/Parser.cs
+++ b/src/PAModel/PAConvert/Parser/Parser.cs
@@ -156,8 +156,9 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Parser
             return false;
         }
 
-        public BlockNode ParseControl()
+        public BlockNode ParseControl(bool isComponent)
         {
+            _yaml.isComponent = isComponent;
             var p = _yaml.ReadNext();
             var control = ParseNestedControl(p);
 

--- a/src/PAModel/PAConvert/Parser/Parser.cs
+++ b/src/PAModel/PAConvert/Parser/Parser.cs
@@ -158,7 +158,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Parser
 
         public BlockNode ParseControl(bool isComponent)
         {
-            _yaml.isComponent = isComponent;
+            _yaml.IsComponent = isComponent;
             var p = _yaml.ReadNext();
             var control = ParseNestedControl(p);
 

--- a/src/PAModel/PAConvert/Yaml/YamlLexer.cs
+++ b/src/PAModel/PAConvert/Yaml/YamlLexer.cs
@@ -527,19 +527,16 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Yaml
             {
                 if (lastSingleQuoteIndex < lineSplit[0].Length)
                 {
-                    if (isComponent)
-                    {
-                         return Error(line, $"Missing closing \' in Component Identifier");
-                    }
-                    return Error(line, $"Missing closing \'in Type node Identifier");
+                    var err = isComponent ? Error(line, $"Missing closing \' in Component Identifier") : Error(line, $"Missing closing \'in Type node Identifier");
+                    return err;
                 }
                 if (isComponent)
                 {
-                    return Error(line, $"Missing closing \' in Component type value");
+                    var err = isComponent ? Error(line, $"Missing closing \' in Component value") : Error(line, $"Missing closing \'in Type node value");
+                    return err;
                 }
-                return Error(line, $"Missing closing \'in Type node type value");
             }
-            return Error(line, $"Missing closing \'in property name");
+            return Error(line, $"Missing closing \'in property");
         }
 
         private YamlToken UnsupportedComment(LineParser line)

--- a/src/PAModel/PAConvert/Yaml/YamlLexer.cs
+++ b/src/PAModel/PAConvert/Yaml/YamlLexer.cs
@@ -129,7 +129,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Yaml
 
         private YamlToken _lastPair;
 
-        public bool isComponent { get; set; } 
+        public bool IsComponent { get; set; } 
 
         // for error handling
         private readonly string _currentFileName;
@@ -351,7 +351,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Yaml
                 if (line.Current == 0) // EOL
                 {
                     if (isEscaped)
-                        return UnsupportedSingleQuote(line, isComponent);
+                        return UnsupportedSingleQuote(line, IsComponent);
 
                     if (requiresClosingDoubleQuote)
                         return Unsupported(line, "Missing closing \".");

--- a/src/PAModel/PAConvert/Yaml/YamlLexer.cs
+++ b/src/PAModel/PAConvert/Yaml/YamlLexer.cs
@@ -520,7 +520,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Yaml
 
         private YamlToken UnsupportedSingleQuote(LineParser line, bool isComponent)
         {
-            string[] lineSplit = line._line.ToString().ToLower().Split(new string[] { " As " }, StringSplitOptions.None);
+            string[] lineSplit = line._line.ToString().ToLower().Split(new string[] { " as " }, StringSplitOptions.None);
 
             if (lineSplit.Length > 2)
             {

--- a/src/PAModel/PAConvert/Yaml/YamlLexer.cs
+++ b/src/PAModel/PAConvert/Yaml/YamlLexer.cs
@@ -342,7 +342,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Yaml
                 if (line.Current == 0) // EOL
                 {
                     if (isEscaped)
-                        return Unsupported(line, "Missing closing \'.");
+                        return Unsupported(line, $"Missing closing \' in {line._line?.Substring(0, line._idx - 1)}");
 
                     if (requiresClosingDoubleQuote)
                         return Unsupported(line, "Missing closing \".");

--- a/src/PAModel/PAConvert/Yaml/YamlLexer.cs
+++ b/src/PAModel/PAConvert/Yaml/YamlLexer.cs
@@ -141,10 +141,10 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Yaml
         // We allow comments, but don't round-trip them. Issue a warning. 
         public SourceLocation? _commentStrippedWarning = null;
 
-        public const string MissingSingleQuoteFunctionNode = "Missing closing \'in Function Node";
-        public const string MissingSingleQuoteComponent = "Missing closing \'in Component";
-        public const string MissingSingleQuoteTypeNode = "Missing closing \'in TypeNode";
-        public const string MissingSingleQuoteProperty = "Missing closing \'in Property";
+        public const string MissingSingleQuoteFunctionNode = "Missing closing \' in Function Node";
+        public const string MissingSingleQuoteComponent = "Missing closing \' in Component";
+        public const string MissingSingleQuoteTypeNode = "Missing closing \' in TypeNode";
+        public const string MissingSingleQuoteProperty = "Missing closing \' in Property";
 
         public YamlLexer(TextReader source, string filenameHint = null)
         {

--- a/src/PAModel/PAConvert/Yaml/YamlLexer.cs
+++ b/src/PAModel/PAConvert/Yaml/YamlLexer.cs
@@ -527,14 +527,9 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Yaml
             {
                 if (lastSingleQuoteIndex < lineSplit[0].Length)
                 {
-                    var err = isComponent ? Error(line, $"Missing closing \' in Component Identifier") : Error(line, $"Missing closing \'in Type node Identifier");
-                    return err;
+                    return isComponent ? Error(line, $"Missing closing \' in Component Identifier") : Error(line, $"Missing closing \'in Type node Identifier");                    
                 }
-                if (isComponent)
-                {
-                    var err = isComponent ? Error(line, $"Missing closing \' in Component value") : Error(line, $"Missing closing \'in Type node value");
-                    return err;
-                }
+                return isComponent ? Error(line, $"Missing closing \' in Component value") : Error(line, $"Missing closing \'in Type node value");                
             }
             return Error(line, $"Missing closing \'in property");
         }

--- a/src/PAModel/Serializers/SourceSerializer.cs
+++ b/src/PAModel/Serializers/SourceSerializer.cs
@@ -471,7 +471,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             try
             {
                 var parser = new Parser.Parser(filePath, fileContents, errors);
-                var controlIR = parser.ParseControl();
+                var controlIR = parser.ParseControl(isComponent);
                 if (controlIR == null)
                 {
                     return; // error condition

--- a/src/PAModelTests/YamlTest.cs
+++ b/src/PAModelTests/YamlTest.cs
@@ -584,7 +584,7 @@ P2: = ""hello"" & ""world""
         {
             var text =
 @"Comp1 As CanvasComponent:
-    fun'c1(Parameter1 As String, Parameter2_000 As String):
+    fun'c1(Parameter1 As String, Parameter2 As String):
         Parameter1:
             Default: =""Text""
         Parameter2:

--- a/src/PAModelTests/YamlTest.cs
+++ b/src/PAModelTests/YamlTest.cs
@@ -558,6 +558,105 @@ P2: = ""hello"" & ""world""
             }
             return val;
         }
+
+        [TestMethod]
+        public void MissingClosingQuoteComponentError()
+        {
+            var text =
+@"Co'mp'1 As CanvasComp'onent:
+    Fill: =RGBA(0, 0, 0, 0)
+    Height: =640
+    OnReset: =
+    Width: =640
+    X: =0
+    Y: =0
+    ZIndex: =1
+";
+            var sr = new StringReader(text);
+            var y = new YamlLexer(sr);
+            y.IsComponent = true;
+
+            AssertLexErrorMessage(y, YamlLexer.MissingSingleQuoteComponent);
+        }
+
+        [TestMethod]
+        public void MissingClosingQuoteFunctionNodeError()
+        {
+            var text =
+@"Comp1 As CanvasComponent:
+    fun'c1(Parameter1 As String, Parameter2_000 As String):
+        Parameter1:
+            Default: =""Text""
+        Parameter2:
+            Default: = ""Text""
+    Fill: =RGBA(0, 0, 0, 0)
+    Height: =640
+    OnReset: =
+    Width: =640
+    X: =0
+    Y: =0
+    ZIndex: =1
+";
+            var sr = new StringReader(text);
+            var y = new YamlLexer(sr);
+            y.IsComponent = true;
+
+            AssertLexErrorMessage(y, YamlLexer.MissingSingleQuoteFunctionNode);
+        }
+
+        [TestMethod]
+        public void MissingClosingQuoteTypeNodeError()
+        {
+            var text =
+@"Scr'een1 As screen:
+    Fill: =RGBA(0, 0, 0, 0)
+    Height: =640
+    OnReset: =
+    Width: =640
+    X: =0
+    Y: =0
+    ZIndex: =1
+";
+            var sr = new StringReader(text);
+            var y = new YamlLexer(sr);
+
+            AssertLexErrorMessage(y, YamlLexer.MissingSingleQuoteTypeNode);
+        }
+
+        [TestMethod]
+        public void MissingClosingQuotePropertyError()
+        {
+            var text =
+@"Screen1 As screen:
+    Fi'll: =RGBA(0, 0, 0, 0)
+    Height: =640
+    OnReset: =
+    Width: =640
+    X: =0
+    Y: =0
+    ZIndex: =1
+";
+            var sr = new StringReader(text);
+            var y = new YamlLexer(sr);
+
+            AssertLexErrorMessage(y, YamlLexer.MissingSingleQuoteProperty);
+        }
+
+        static void AssertLexErrorMessage(YamlLexer y, string expectedErrorMessage)
+        {
+            var p = y.ReadNext();
+            while (p.Kind != YamlTokenKind.EndOfFile)
+            {
+                if (p.Kind == YamlTokenKind.Error)
+                {
+                    Assert.AreEqual(p.Value, expectedErrorMessage);
+                    return;
+                }               
+                p = y.ReadNext();
+            }
+            Assert.Fail();
+        }
+
         #endregion
 
     }


### PR DESCRIPTION
## Problem
Currently missing closing ' error gives no details on what identifier or cases cause this type of error.

## Solution
Improving the missing closing quote error log with type details to debug the error better
![image](https://user-images.githubusercontent.com/98551644/172454148-0e3ccb3e-1f0e-43dc-b045-33d790b7608e.png)

## Validation

- Added Unit tests
- Roundtrip testing the test .msapps
- Roundtrip testing the test battery .msapps