### PR TITLE
Remove Filename Output when Parsing Error Occurs

### DIFF
--- a/src/PAModel/PAConvert/Error.cs
+++ b/src/PAModel/PAConvert/Error.cs
@@ -38,11 +38,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             sb.Append($"PA{(int)Code}: ");
             sb.Append(this.Message);
 
-            if (this.Span.FileName != null)
-            {
-                sb.Append(" at ");
-                sb.Append(this.Span);
-            }
             return sb.ToString();
         }
     }


### PR DESCRIPTION
No longer have filename as output when parsing error occurs.