### PR TITLE
handling null ref exception in RestoreAssetFilePaths

### DIFF
--- a/src/PAModel/CanvasDocument.cs
+++ b/src/PAModel/CanvasDocument.cs
@@ -2,19 +2,17 @@
 // Licensed under the MIT License.
 
 using Microsoft.AppMagic.Authoring.Persistence;
-using Microsoft.PowerPlatform.Formulas.Tools.IR;
+using Microsoft.PowerPlatform.Formulas.Tools.ControlTemplates;
 using Microsoft.PowerPlatform.Formulas.Tools.EditorState;
+using Microsoft.PowerPlatform.Formulas.Tools.IR;
+using Microsoft.PowerPlatform.Formulas.Tools.Schemas;
+using Microsoft.PowerPlatform.Formulas.Tools.Schemas.PcfControl;
+using Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms;
+using Microsoft.PowerPlatform.Formulas.Tools.Utility;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using Microsoft.PowerPlatform.Formulas.Tools.ControlTemplates;
-using Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms;
-using System.ComponentModel;
-using System.Runtime.InteropServices;
-using Microsoft.PowerPlatform.Formulas.Tools.Schemas;
 using System.IO;
-using Microsoft.PowerPlatform.Formulas.Tools.Utility;
-using Microsoft.PowerPlatform.Formulas.Tools.Schemas.PcfControl;
+using System.Linq;
 
 namespace Microsoft.PowerPlatform.Formulas.Tools
 {
@@ -625,16 +623,19 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         private void RestoreAssetFilePaths()
         {
             // For apps unpacked before this asset rewrite was added, skip the restore step
-            if (_entropy.LocalResourceFileNames == null)
+            if (_entropy?.LocalResourceFileNames == null)
                 return;
 
-            if (_resourcesJson == null || _assetFiles == null)
+            if (_resourcesJson?.Resources == null || _assetFiles == null)
                 return;
 
             var maxFileNumber = FindMaxEntropyFileName();
 
             foreach (var resource in _resourcesJson.Resources)
             {
+                if (resource == null)
+                    continue;
+
                 if (resource.ResourceKind != ResourceKind.LocalFile)
                     continue;
 

--- a/src/PAModelTests/WriteTransformTests.cs
+++ b/src/PAModelTests/WriteTransformTests.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 using Microsoft.PowerPlatform.Formulas.Tools;
+using Microsoft.PowerPlatform.Formulas.Tools.Schemas;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
-using System.Linq;
 
 namespace PAModelTests
 {
@@ -41,6 +41,38 @@ namespace PAModelTests
 
             // explicitly setting it to null
             msapp._assetFiles = null;
+
+            msapp.ApplyBeforeMsAppWriteTransforms(errors);
+            Assert.IsFalse(errors.HasErrors);
+        }
+
+        [DataTestMethod]
+        [DataRow("AccountPlanReviewerMaster.msapp")]
+        public void TestResourcesJsonIsNullWhenRestoringAssetFilePaths(string filename)
+        {
+            var root = Path.Combine(Environment.CurrentDirectory, "Apps", filename);
+            Assert.IsTrue(File.Exists(root));
+
+            (var msapp, var errors) = CanvasDocument.LoadFromMsapp(root);
+            errors.ThrowOnErrors();
+
+            msapp._resourcesJson = null;
+
+            msapp.ApplyBeforeMsAppWriteTransforms(errors);
+            Assert.IsFalse(errors.HasErrors);
+        }
+
+        [DataTestMethod]
+        [DataRow("AccountPlanReviewerMaster.msapp")]
+        public void TestResourcesInResourcesJsonIsNullWhenRestoringAssetFilePaths(string filename)
+        {
+            var root = Path.Combine(Environment.CurrentDirectory, "Apps", filename);
+            Assert.IsTrue(File.Exists(root));
+
+            (var msapp, var errors) = CanvasDocument.LoadFromMsapp(root);
+            errors.ThrowOnErrors();
+
+            msapp._resourcesJson = new ResourcesJson() { Resources = null };
 
             msapp.ApplyBeforeMsAppWriteTransforms(errors);
             Assert.IsFalse(errors.HasErrors);


### PR DESCRIPTION
If this is related to an issue open in GitHub, please link it to this ticket and put the URL here.

## Problem

Null Reference Exception in CanvasDocument.RestoreAssetFilePaths

## Solution

Adding null checks and taking appropriate actions

## Changes
-Added null check conditions in CanvasDocument.RestoreAssetFilePaths

## Validation

Unit testing