### PR TITLE
Reduced Error Message Body Length Avoiding Truncated Error Telemetry

### DIFF
--- a/src/PAModel/PAConvert/ErrorContainer.cs
+++ b/src/PAModel/PAConvert/ErrorContainer.cs
@@ -1,10 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// TODO: Sort Imports
 using Microsoft.PowerPlatform.Formulas.Tools.IR;
-using Microsoft.PowerPlatform.Formulas.Tools.Parser;
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -27,7 +24,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         internal void AddError(ErrorCode code, SourceLocation span, string errorMessage)
         {
             var error = new Error(code, span, errorMessage);
-            // TODO: Capture count in a new private variable
+
             if (error.IsError) { _countErrors++; } else { _countWarnings++; }
 
             if (_errors.Count < _errorsToPrint)
@@ -66,14 +63,13 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         {
             foreach (var error in this)
             {
-                // if (error.IsError) { countErrors++; } else { countWarnings++; }
                 output.WriteLine(error);
             }
 
             if (_countErrors > _errorsToPrint)
             {
                 var additionalErrors = _countErrors - _errorsToPrint;
-                output.WriteLine($"...and {additionalErrors} errors.");
+                output.WriteLine($"...and {additionalErrors} more errors.");
             }
 
             if (_countErrors + _countWarnings > 0)

--- a/src/PAModel/PAConvert/ErrorContainer.cs
+++ b/src/PAModel/PAConvert/ErrorContainer.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+// TODO: Sort Imports
 using Microsoft.PowerPlatform.Formulas.Tools.IR;
 using Microsoft.PowerPlatform.Formulas.Tools.Parser;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -17,11 +19,22 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
     public class ErrorContainer : IEnumerable<Error>
     {
         private List<Error> _errors = new List<Error>();
-                
+        private int _countErrors = 0;
+        private int _countWarnings = 0;
+        // TODO: Determine limit
+        private const int _errorsToPrint = 10; // Enforcing a limit in code to prevent oversized message body from getting trimmed
+
         internal void AddError(ErrorCode code, SourceLocation span, string errorMessage)
         {
-            _errors.Add(new Error(code, span, errorMessage));
-        }        
+            var error = new Error(code, span, errorMessage);
+            // TODO: Capture count in a new private variable
+            if (error.IsError) { _countErrors++; } else { _countWarnings++; }
+
+            if (_errors.Count < _errorsToPrint)
+            {
+                _errors.Add(error);
+            }
+        }
 
         public bool HasErrors => _errors.Any(error => error.IsError);
 
@@ -51,18 +64,21 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         // Helper for writing out errors.
         public void Write(TextWriter output)
         {
-            int countWarnings = 0;
-            int countErrors = 0;
-
             foreach (var error in this)
             {
-                if (error.IsError) { countErrors++; } else { countWarnings++;  }
+                // if (error.IsError) { countErrors++; } else { countWarnings++; }
                 output.WriteLine(error);
             }
 
-            if (countErrors + countWarnings > 0)
+            if (_countErrors > _errorsToPrint)
             {
-                output.WriteLine($"{countErrors} errors, {countWarnings} warnings.");
+                var additionalErrors = _countErrors - _errorsToPrint;
+                output.WriteLine($"...and {additionalErrors} errors.");
+            }
+
+            if (_countErrors + _countWarnings > 0)
+            {
+                output.WriteLine($"{_countErrors} errors, {_countWarnings} warnings.");
             }
         }
 

--- a/src/PAModel/PAConvert/ErrorContainer.cs
+++ b/src/PAModel/PAConvert/ErrorContainer.cs
@@ -18,7 +18,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         private List<Error> _errors = new List<Error>();
         private int _countErrors = 0;
         private int _countWarnings = 0;
-        // TODO: Determine limit
         private const int _errorsToPrint = 10; // Enforcing a limit in code to prevent oversized message body from getting trimmed
 
         internal void AddError(ErrorCode code, SourceLocation span, string errorMessage)

--- a/src/PAModelTests/ErrorTests.cs
+++ b/src/PAModelTests/ErrorTests.cs
@@ -4,7 +4,6 @@
 using Microsoft.PowerPlatform.Formulas.Tools;
 using System;
 using System.IO;
-using System.Text.Json;
 using Xunit;
 
 namespace PAModelTests
@@ -95,36 +94,29 @@ namespace PAModelTests
         }
 
         [Theory]
-        // [InlineData("simpleChanged1.json", "simpleChanged2.json", "simpleChangedOutput.txt")]
-        // [InlineData("complexChanged1.json", "complexChanged2.json", "complexChangedOutput.txt")]
-        // [InlineData("simpleAdded1.json", "simpleAdded2.json", "simpleAddedOutput.txt")]
-        // [InlineData("complexAdded1.json", "complexAdded2.json", "complexAddedOutput.txt")]
-        // [InlineData("simpleArray1.json", "simpleArray2.json", "simpleArrayOutput.txt")]
-        // [InlineData("emptyNestedArray1.json", "emptyNestedArray2.json", "emptyNestedArrayOutput.txt")]
-        [InlineData("simpleRemoved1_Extra.json", "simpleRemoved2.json", "simpleRemoved_Extra_Output.txt")]
-        // [InlineData("complexRemoved1.json", "complexRemoved2.json", "complexRemovedOutput.txt")]
+        [InlineData("ErrorLinesTest_beforePropertiesRemoved_Less.json", "ErrorLinesTest_afterPropertiesRemoved.json", "ErrorLinesTest_beforePropertiesRemoved_Less_Output.txt")]
+        [InlineData("ErrorLinesTest_beforePropertiesRemoved_Limit.json", "ErrorLinesTest_afterPropertiesRemoved.json", "ErrorLinesTest_beforePropertiesRemoved_Limit_Output.txt")]
+        [InlineData("ErrorLinesTest_beforePropertiesRemoved_Excess.json", "ErrorLinesTest_afterPropertiesRemoved.json", "ErrorLinesTest_beforePropertiesRemoved_Excess_Output.txt")]
         public void TestMessageWithTooManyErrors(string before, string after, string output)
         {
 
-            string path1 = Path.Combine(Environment.CurrentDirectory, "TestData", before);
-            string path2 = Path.Combine(Environment.CurrentDirectory, "TestData", after);
-            string path3 = Path.Combine(Environment.CurrentDirectory, "TestData", output);
+            string beforeFilePath = Path.Combine(Environment.CurrentDirectory, "TestData", before);
+            string afterFilePath = Path.Combine(Environment.CurrentDirectory, "TestData", after);
+            string outputFilePath = Path.Combine(Environment.CurrentDirectory, "TestData", output);
 
             ErrorContainer errorContainer = new ErrorContainer();
 
-            byte[] jsonString1 = File.ReadAllBytes(path1);
-            byte[] jsonString2 = File.ReadAllBytes(path2);
+            byte[] beforeFileJsonString = File.ReadAllBytes(beforeFilePath);
+            byte[] afterFileJsonString = File.ReadAllBytes(afterFilePath);
 
-            var jsonDictionary1 = MsAppTest.FlattenJson(jsonString1);
-            var jsonDictionary2 = MsAppTest.FlattenJson(jsonString2);
+            var beforeFileJsonDictionary = MsAppTest.FlattenJson(beforeFileJsonString);
+            var afterFileJsonDictionary = MsAppTest.FlattenJson(afterFileJsonString);
 
-            // IsMismatched on mismatched files
-            // TODO: More variations
-            MsAppTest.CheckPropertyChangedRemoved(jsonDictionary1, jsonDictionary2, errorContainer, "");
-            MsAppTest.CheckPropertyAdded(jsonDictionary1, jsonDictionary2, errorContainer, "");
-
+            // Run a test to produce errors
+            MsAppTest.CheckPropertyChangedRemoved(beforeFileJsonDictionary, afterFileJsonDictionary, errorContainer, "");
+            
             // Confirm that the unit tests have the expected output
-            Assert.Equal(File.ReadAllText(path3), errorContainer.ToString());
+            Assert.Equal(File.ReadAllText(outputFilePath), errorContainer.ToString());
         }
     }
 }

--- a/src/PAModelTests/ErrorTests.cs
+++ b/src/PAModelTests/ErrorTests.cs
@@ -44,7 +44,7 @@ namespace PAModelTests
 
             (var doc, var errors) = CanvasDocument.LoadFromSources(PathToValidMsapp);
             Assert.True(errors.HasErrors);
-            Assert.Null(doc);            
+            Assert.Null(doc);
         }
 
         [Fact]
@@ -59,7 +59,7 @@ namespace PAModelTests
         public void BadWriteDir()
         {
             string path = null;
-            Assert.Throws<DocumentException>(() => DirectoryWriter.EnsureFileDirExists(path));   
+            Assert.Throws<DocumentException>(() => DirectoryWriter.EnsureFileDirExists(path));
         }
 
         [Theory]
@@ -71,7 +71,6 @@ namespace PAModelTests
         [InlineData("simpleRemoved1.json", "simpleRemoved2.json", "simpleRemovedOutput.txt")]
         [InlineData("emptyNestedArray1.json", "emptyNestedArray2.json", "emptyNestedArrayOutput.txt")]
         [InlineData("simpleArray1.json", "simpleArray2.json", "simpleArrayOutput.txt")]
-
         public void TestJSONValueChanged(string file1, string file2, string file3)
         {
 
@@ -88,6 +87,39 @@ namespace PAModelTests
             var jsonDictionary2 = MsAppTest.FlattenJson(jsonString2);
 
             // IsMismatched on mismatched files
+            MsAppTest.CheckPropertyChangedRemoved(jsonDictionary1, jsonDictionary2, errorContainer, "");
+            MsAppTest.CheckPropertyAdded(jsonDictionary1, jsonDictionary2, errorContainer, "");
+
+            // Confirm that the unit tests have the expected output
+            Assert.Equal(File.ReadAllText(path3), errorContainer.ToString());
+        }
+
+        [Theory]
+        // [InlineData("simpleChanged1.json", "simpleChanged2.json", "simpleChangedOutput.txt")]
+        // [InlineData("complexChanged1.json", "complexChanged2.json", "complexChangedOutput.txt")]
+        // [InlineData("simpleAdded1.json", "simpleAdded2.json", "simpleAddedOutput.txt")]
+        // [InlineData("complexAdded1.json", "complexAdded2.json", "complexAddedOutput.txt")]
+        // [InlineData("simpleArray1.json", "simpleArray2.json", "simpleArrayOutput.txt")]
+        // [InlineData("emptyNestedArray1.json", "emptyNestedArray2.json", "emptyNestedArrayOutput.txt")]
+        [InlineData("simpleRemoved1_Extra.json", "simpleRemoved2.json", "simpleRemoved_Extra_Output.txt")]
+        // [InlineData("complexRemoved1.json", "complexRemoved2.json", "complexRemovedOutput.txt")]
+        public void TestMessageWithTooManyErrors(string before, string after, string output)
+        {
+
+            string path1 = Path.Combine(Environment.CurrentDirectory, "TestData", before);
+            string path2 = Path.Combine(Environment.CurrentDirectory, "TestData", after);
+            string path3 = Path.Combine(Environment.CurrentDirectory, "TestData", output);
+
+            ErrorContainer errorContainer = new ErrorContainer();
+
+            byte[] jsonString1 = File.ReadAllBytes(path1);
+            byte[] jsonString2 = File.ReadAllBytes(path2);
+
+            var jsonDictionary1 = MsAppTest.FlattenJson(jsonString1);
+            var jsonDictionary2 = MsAppTest.FlattenJson(jsonString2);
+
+            // IsMismatched on mismatched files
+            // TODO: More variations
             MsAppTest.CheckPropertyChangedRemoved(jsonDictionary1, jsonDictionary2, errorContainer, "");
             MsAppTest.CheckPropertyAdded(jsonDictionary1, jsonDictionary2, errorContainer, "");
 

--- a/src/PAModelTests/PAModelTests.csproj
+++ b/src/PAModelTests/PAModelTests.csproj
@@ -29,9 +29,6 @@
     <Content Include="TestData\*.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <Content Include="TestData\*.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
     <Content Include="SrcBaseline\*.fx.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
@@ -50,28 +47,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="TestData\complexAddedOutput.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TestData\complexChangedOutput.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TestData\complexRemovedOutput.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TestData\simpleArrayOutput.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TestData\emptyNestedArrayOutput.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TestData\simpleAddedOutput.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TestData\simpleChangedOutput.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TestData\simpleRemovedOutput.txt">
+    <None Update="TestData\*.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/src/PAModelTests/TestData/ErrorLinesTest_afterPropertiesRemoved.json
+++ b/src/PAModelTests/TestData/ErrorLinesTest_afterPropertiesRemoved.json
@@ -1,0 +1,7 @@
+{
+  "Words": {
+    "Noun": "Tree",
+    "Adjective": "Green",
+    "Verb": "Run"
+  }
+}

--- a/src/PAModelTests/TestData/ErrorLinesTest_beforePropertiesRemoved_Excess.json
+++ b/src/PAModelTests/TestData/ErrorLinesTest_beforePropertiesRemoved_Excess.json
@@ -1,0 +1,21 @@
+{
+  "Words": {
+    "Noun": "Tree",
+    "Adjective": "Green",
+    "Verb": "Run",
+    "Adverb1": "Slow",
+    "Adverb2": "Fast",
+    "Adverb3": "Great",
+    "Adverb4": "Poor"
+  },
+  "Numbers": {
+    "Single": 1,
+    "Double": 52,
+    "Triple1": 905,
+    "Triple2": 910,
+    "Triple3": 909,
+    "Triple4": 908,
+    "Triple5": 907,
+    "Triple6": 906
+  }
+}

--- a/src/PAModelTests/TestData/ErrorLinesTest_beforePropertiesRemoved_Excess_Output.txt
+++ b/src/PAModelTests/TestData/ErrorLinesTest_beforePropertiesRemoved_Excess_Output.txt
@@ -1,0 +1,12 @@
+Error   PA3015: Property Removed: Words.Adverb1
+Error   PA3015: Property Removed: Words.Adverb2
+Error   PA3015: Property Removed: Words.Adverb3
+Error   PA3015: Property Removed: Words.Adverb4
+Error   PA3015: Property Removed: Numbers.Single
+Error   PA3015: Property Removed: Numbers.Double
+Error   PA3015: Property Removed: Numbers.Triple1
+Error   PA3015: Property Removed: Numbers.Triple2
+Error   PA3015: Property Removed: Numbers.Triple3
+Error   PA3015: Property Removed: Numbers.Triple4
+...and 2 more errors.
+12 errors, 0 warnings.

--- a/src/PAModelTests/TestData/ErrorLinesTest_beforePropertiesRemoved_Less.json
+++ b/src/PAModelTests/TestData/ErrorLinesTest_beforePropertiesRemoved_Less.json
@@ -1,0 +1,13 @@
+{
+  "Words": {
+    "Noun": "Tree",
+    "Adjective": "Green",
+    "Verb": "Run",
+    "Adverb4": "Poor"
+  },
+  "Numbers": {
+    "Single": 1,
+    "Double": 52,
+    "Triple6": 906
+  }
+}

--- a/src/PAModelTests/TestData/ErrorLinesTest_beforePropertiesRemoved_Less_Output.txt
+++ b/src/PAModelTests/TestData/ErrorLinesTest_beforePropertiesRemoved_Less_Output.txt
@@ -1,0 +1,5 @@
+Error   PA3015: Property Removed: Words.Adverb4
+Error   PA3015: Property Removed: Numbers.Single
+Error   PA3015: Property Removed: Numbers.Double
+Error   PA3015: Property Removed: Numbers.Triple6
+4 errors, 0 warnings.

--- a/src/PAModelTests/TestData/ErrorLinesTest_beforePropertiesRemoved_Limit.json
+++ b/src/PAModelTests/TestData/ErrorLinesTest_beforePropertiesRemoved_Limit.json
@@ -1,0 +1,19 @@
+{
+  "Words": {
+    "Noun": "Tree",
+    "Adjective": "Green",
+    "Verb": "Run",
+    "Adverb1": "Slow",
+    "Adverb2": "Fast",
+    "Adverb3": "Great",
+    "Adverb4": "Poor"
+  },
+  "Numbers": {
+    "Single": 1,
+    "Double": 52,
+    "Triple1": 905,
+    "Triple2": 910,
+    "Triple3": 909,
+    "Triple6": 906
+  }
+}

--- a/src/PAModelTests/TestData/ErrorLinesTest_beforePropertiesRemoved_Limit_Output.txt
+++ b/src/PAModelTests/TestData/ErrorLinesTest_beforePropertiesRemoved_Limit_Output.txt
@@ -1,0 +1,11 @@
+Error   PA3015: Property Removed: Words.Adverb1
+Error   PA3015: Property Removed: Words.Adverb2
+Error   PA3015: Property Removed: Words.Adverb3
+Error   PA3015: Property Removed: Words.Adverb4
+Error   PA3015: Property Removed: Numbers.Single
+Error   PA3015: Property Removed: Numbers.Double
+Error   PA3015: Property Removed: Numbers.Triple1
+Error   PA3015: Property Removed: Numbers.Triple2
+Error   PA3015: Property Removed: Numbers.Triple3
+Error   PA3015: Property Removed: Numbers.Triple6
+10 errors, 0 warnings.


### PR DESCRIPTION
## Problem
The `message` column in our internal telemetry databases has limited maximum length, and due to this, certain errors that were logged by this application were getting truncated because the message body was too long (by several hundreds of orders of magnitude) and therefore this was resulting in bad telemetry data for errors.

This was happening because the application was appending every single error message during a command execution to the error message body before publishing the error object. In some cases, like canvas `pack` and `unpack` where the round trip errors could lead to 100s of lines of errors, this was causing the entire message body to get truncated, leading to loss of valuable telemetry data used in subsequent columns.

## Solution
To fix this, we have borrowed inspiration from the .NET exception message, and have implemented a similar solution here - Now the error output restricts itself to 10 error lines, and for all the excess lines, only a count is reported E.g. "...and 28 more errors". This ensures that no matter how many errors a particular action result has, we always have a fixed length error message body, that also informs the user that there are more errors number that need to be resolved after the first 10.

![image](https://user-images.githubusercontent.com/1485950/186264486-db79eda7-d4fa-42c7-bed1-f4bb66d9b18b.png)

As a side effect, this change applies the same solution to the error logs that go to the console as well, this _could_ be preferred since it maintains consistency across all of the error log outputs, and is similar to behavior seen elsewhere in error log outputs across .NET platforms.

## Changes
- The error container function `AddError` now also checks if the `_errors` collection is bigger than 10 objects, and if so skips adding any more error objects to the collection. It instead just keeps track of the count of errors that it attempts to add
- The `AddError` function also now keeps track of the total number of errors and warnings and saves them to newly introduced private variables `_countErrors` and `_countWarnings` - these were local variables in the `Write` function previously.
- The `Write` function now outputs a maximum of 10 error lines and once this limit has reached, it will stop and print a statement "...and X more errors" - where X is the count of the additional errors in the collection.
- The limit of 10 is set to a constant private variable `_errorsToPrint` - the number 10 has been arbitrarily determined to keep the output size to a suitable level.

## Validation
Unit test `TestMessageWithTooManyErrors` has been added to check for the error output. Input data for less, limit, and excess error lines with the expected output has been added to ensure this works. However, we would need to run this against a Kusto environment to fully validate this change.