### PR TITLE
adding checks for possible nulls and logging any unhandled null ref a…

### DIFF
--- a/src/PAModelTests/WriteTransformTests.cs
+++ b/src/PAModelTests/WriteTransformTests.cs
@@ -92,7 +92,6 @@ namespace PAModelTests
             (var msapp, var errors) = CanvasDocument.LoadFromMsapp(root);
             errors.ThrowOnErrors();
 
-
             using var sourcesTempDir = new TempDir();
             var sourcesTempDirPath = sourcesTempDir.Dir;
             msapp.SaveToSources(sourcesTempDirPath);


### PR DESCRIPTION
…s internal error

If this is related to an issue open in GitHub, please link it to this ticket and put the URL here.

## Problem

What is the issue we are attempting to solve?
Null Ref Exception was logged in the dashboard in the MsAppSerializer.GetMsAppFiles() function. The function is huge so it is extremely difficult to figure out what cause null ref exception. Tried reproducing it but no success.

## Solution

What are we doing to solve this issue?
Added null checks for possible cases. Null ref was generated in different functions because of these cases in the past. Wrapped the code in try/catch to catch the null ref and log it as an internal error which will reveal more like details like line number on which null ref occured

## Changes
Added null checks for possible cases of null ref
Wrapped code in try catch to log null ref as internal error which will reveal more details to debug if null ref occurs again

## Validation

- How did you verify that this issue is truly fixed?
Unit Tests
