### PR TITLE
Handling NullRefException at CanvasDocument.<>c.<StabilizeAssetFilePaths>

### DIFF
--- a/src/PAModel/CanvasDocument.cs
+++ b/src/PAModel/CanvasDocument.cs
@@ -531,7 +531,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             // If a name matches caseinsensitive but not casesensitive, it is a candidate for rename
             var caseInsensitiveNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var caseSensitiveNames = new HashSet<string>(StringComparer.Ordinal);
-            foreach (var resource in _resourcesJson.Resources.Where(resource => resource != null && resource.Name != null).OrderBy(resource => resource.Name, StringComparer.Ordinal))
+            foreach (var resource in _resourcesJson.Resources.Where(resource => resource?.Name != null)
+                                                             .OrderBy(resource => resource.Name, StringComparer.Ordinal))
             {
                 if (resource.ResourceKind != ResourceKind.LocalFile)
                     continue;
@@ -546,7 +547,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             var resourceStabilizer = new HashSet<string>(StringComparer.Ordinal);
 
             // Update AssetFile paths
-            foreach (var resource in _resourcesJson.Resources.Where(resource => resource != null && resource.Name != null).OrderBy(resource => resource.Name, StringComparer.Ordinal))
+            foreach (var resource in _resourcesJson.Resources.Where(resource => resource?.Name != null)
+                                                             .OrderBy(resource => resource.Name, StringComparer.Ordinal))
             {
                 if (resource.ResourceKind != ResourceKind.LocalFile)
                     continue;

--- a/src/PAModel/CanvasDocument.cs
+++ b/src/PAModel/CanvasDocument.cs
@@ -531,12 +531,9 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             // If a name matches caseinsensitive but not casesensitive, it is a candidate for rename
             var caseInsensitiveNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var caseSensitiveNames = new HashSet<string>(StringComparer.Ordinal);
-            foreach (var resource in _resourcesJson.Resources.Where(resource => resource?.Name != null)
+            foreach (var resource in _resourcesJson.Resources.Where(resource => resource?.Name != null && resource.ResourceKind != ResourceKind.LocalFile)
                                                              .OrderBy(resource => resource.Name, StringComparer.Ordinal))
             {
-                if (resource.ResourceKind != ResourceKind.LocalFile)
-                    continue;
-
                 if (caseInsensitiveNames.Add(resource.Name))
                 {
                     caseSensitiveNames.Add(resource.Name);
@@ -547,12 +544,9 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             var resourceStabilizer = new HashSet<string>(StringComparer.Ordinal);
 
             // Update AssetFile paths
-            foreach (var resource in _resourcesJson.Resources.Where(resource => resource?.Name != null)
+            foreach (var resource in _resourcesJson.Resources.Where(resource => resource?.Name != null && resource.ResourceKind != ResourceKind.LocalFile)
                                                              .OrderBy(resource => resource.Name, StringComparer.Ordinal))
             {
-                if (resource.ResourceKind != ResourceKind.LocalFile)
-                    continue;
-
                 var originalName = resource.Name;
                 var assetFilePath = GetAssetFilePathWithoutPrefix(resource.Path);
                 var pathToStabilize = resource.Path;

--- a/src/PAModel/CanvasDocument.cs
+++ b/src/PAModel/CanvasDocument.cs
@@ -531,7 +531,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             // If a name matches caseinsensitive but not casesensitive, it is a candidate for rename
             var caseInsensitiveNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var caseSensitiveNames = new HashSet<string>(StringComparer.Ordinal);
-            foreach (var resource in _resourcesJson.Resources.Where(resource => resource?.Name != null && resource.ResourceKind != ResourceKind.LocalFile)
+            foreach (var resource in _resourcesJson.Resources.Where(resource => resource?.Name != null && resource.ResourceKind == ResourceKind.LocalFile)
                                                              .OrderBy(resource => resource.Name, StringComparer.Ordinal))
             {
                 if (caseInsensitiveNames.Add(resource.Name))
@@ -544,7 +544,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             var resourceStabilizer = new HashSet<string>(StringComparer.Ordinal);
 
             // Update AssetFile paths
-            foreach (var resource in _resourcesJson.Resources.Where(resource => resource?.Name != null && resource.ResourceKind != ResourceKind.LocalFile)
+            foreach (var resource in _resourcesJson.Resources.Where(resource => resource?.Name != null && resource.ResourceKind == ResourceKind.LocalFile)
                                                              .OrderBy(resource => resource.Name, StringComparer.Ordinal))
             {
                 var originalName = resource.Name;

--- a/src/PAModel/CanvasDocument.cs
+++ b/src/PAModel/CanvasDocument.cs
@@ -531,7 +531,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             // If a name matches caseinsensitive but not casesensitive, it is a candidate for rename
             var caseInsensitiveNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var caseSensitiveNames = new HashSet<string>(StringComparer.Ordinal);
-            foreach (var resource in _resourcesJson.Resources.Where(resource => resource != null).OrderBy(resource => resource.Name, StringComparer.Ordinal))
+            foreach (var resource in _resourcesJson.Resources.Where(resource => resource != null && resource.Name != null).OrderBy(resource => resource.Name, StringComparer.Ordinal))
             {
                 if (resource.ResourceKind != ResourceKind.LocalFile)
                     continue;
@@ -546,7 +546,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             var resourceStabilizer = new HashSet<string>(StringComparer.Ordinal);
 
             // Update AssetFile paths
-            foreach (var resource in _resourcesJson.Resources.Where(resource => resource != null).OrderBy(resource => resource.Name, StringComparer.Ordinal))
+            foreach (var resource in _resourcesJson.Resources.Where(resource => resource != null && resource.Name != null).OrderBy(resource => resource.Name, StringComparer.Ordinal))
             {
                 if (resource.ResourceKind != ResourceKind.LocalFile)
                     continue;

--- a/src/PAModel/CanvasDocument.cs
+++ b/src/PAModel/CanvasDocument.cs
@@ -528,11 +528,10 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         {
             _entropy.LocalResourceFileNames.Clear();
 
-
             // If a name matches caseinsensitive but not casesensitive, it is a candidate for rename
             var caseInsensitiveNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var caseSensitiveNames = new HashSet<string>(StringComparer.Ordinal);
-            foreach (var resource in _resourcesJson.Resources.OrderBy(resource => resource.Name, StringComparer.Ordinal))
+            foreach (var resource in _resourcesJson.Resources.Where(resource => resource != null).OrderBy(resource => resource.Name, StringComparer.Ordinal))
             {
                 if (resource.ResourceKind != ResourceKind.LocalFile)
                     continue;
@@ -547,7 +546,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             var resourceStabilizer = new HashSet<string>(StringComparer.Ordinal);
 
             // Update AssetFile paths
-            foreach (var resource in _resourcesJson.Resources.OrderBy(resource => resource.Name, StringComparer.Ordinal))
+            foreach (var resource in _resourcesJson.Resources.Where(resource => resource != null).OrderBy(resource => resource.Name, StringComparer.Ordinal))
             {
                 if (resource.ResourceKind != ResourceKind.LocalFile)
                     continue;

--- a/src/PAModelTests/ReadTransformTests.cs
+++ b/src/PAModelTests/ReadTransformTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using Microsoft.PowerPlatform.Formulas.Tools;
+using Microsoft.PowerPlatform.Formulas.Tools.Schemas;
+using Microsoft.PowerPlatform.Formulas.Tools.Utility;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
@@ -27,6 +29,28 @@ namespace PAModelTests
 
             Assert.AreEqual(errorContainer.HasErrors, hasErrors);
             Assert.AreEqual(errorContainer.HasWarnings, hasWarnings);
+        }
+
+        [TestMethod]
+        public void TestAssetFileCollision()
+        {
+            var doc = new CanvasDocument();
+
+            var resource1 = new ResourceJson()
+            {
+                Name = "Image",
+                Path = "Assets\\Images\\Image.png",
+                FileName = "Image.png",
+                ResourceKind = ResourceKind.LocalFile,
+                Content = ContentKind.Image,
+            };
+            doc._assetFiles.Add(new FilePath("Images", "Image.png"), new FileEntry());
+
+            // passing null resource in resourcesJson
+            doc._resourcesJson = new ResourcesJson() { Resources = new ResourceJson[] { resource1, null } };
+
+            var errorContainer = new ErrorContainer();
+            Assert.ThrowsException<NullReferenceException>(() => doc.StabilizeAssetFilePaths(errorContainer));
         }
     }
 }

--- a/src/PAModelTests/ReadTransformTests.cs
+++ b/src/PAModelTests/ReadTransformTests.cs
@@ -32,13 +32,14 @@ namespace PAModelTests
         }
 
         [TestMethod]
-        public void TestAssetFileCollision()
+        public void TestNullResource()
         {
             var doc = new CanvasDocument();
 
+            // resource name null case
             var resource1 = new ResourceJson()
             {
-                Name = "Image",
+                Name = null,
                 Path = "Assets\\Images\\Image.png",
                 FileName = "Image.png",
                 ResourceKind = ResourceKind.LocalFile,
@@ -50,7 +51,9 @@ namespace PAModelTests
             doc._resourcesJson = new ResourcesJson() { Resources = new ResourceJson[] { resource1, null } };
 
             var errorContainer = new ErrorContainer();
-            Assert.ThrowsException<NullReferenceException>(() => doc.StabilizeAssetFilePaths(errorContainer));
+            doc.StabilizeAssetFilePaths(errorContainer);
+
+            Assert.AreEqual(errorContainer.HasErrors, false);
         }
     }
 }


### PR DESCRIPTION
## Problem
![image](https://user-images.githubusercontent.com/98551644/196265279-a851342c-c748-4b60-bc23-6bcb9d8b9791.png)

Reproduced the same error in unit test 
![image](https://user-images.githubusercontent.com/98551644/196264322-2455daec-89fc-4f4b-b763-80b055b89e76.png)

## Solution

Handle null resources in the StabilizeAssetFilePaths() while iterating through resourceJson.
Resource name null case handled too (might not be a valid scenario, but still an extra safe approach).

## Validation

- Unit Testing