### PR TITLE
Handling localdatabase references when unpacking

### DIFF
--- a/src/PAModel/Serializers/SourceSerializer.cs
+++ b/src/PAModel/Serializers/SourceSerializer.cs
@@ -822,7 +822,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             app._dataSourceReferences = new Dictionary<string, LocalDatabaseReferenceJson>();
             foreach (var dataSourceReferenceEntry in dataSourceReferences)
             {
-                if (dataSourceReferenceEntry.Value.dataSources.Count > 0)
+                if (dataSourceReferenceEntry.Value.dataSources.Count > 0 || dataSourceReferenceEntry.Value.ExtensionData.Count > 0)
                 {
                     app._dataSourceReferences.Add(dataSourceReferenceEntry);
                 }

--- a/src/PAModel/Serializers/SourceSerializer.cs
+++ b/src/PAModel/Serializers/SourceSerializer.cs
@@ -822,10 +822,10 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             app._dataSourceReferences = new Dictionary<string, LocalDatabaseReferenceJson>();
             foreach (var dataSourceReferenceEntry in dataSourceReferences)
             {
-                if (dataSourceReferenceEntry.Value.dataSources.Count > 0 || dataSourceReferenceEntry.Value.ExtensionData.Count > 0)
-                {
+                // if (dataSourceReferenceEntry.Value.dataSources.Count > 0 || dataSourceReferenceEntry.Value.ExtensionData.Count > 0)
+                // {
                     app._dataSourceReferences.Add(dataSourceReferenceEntry);
-                }
+                // }
             }
 
             // key is filename, value is stringified xml

--- a/src/PAModel/Serializers/SourceSerializer.cs
+++ b/src/PAModel/Serializers/SourceSerializer.cs
@@ -818,14 +818,11 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                     localDatabaseReferenceJson.dataSources.Add(tableDef.EntityName, tableDef.LocalReferenceDSJson);
                 }
             }
-            // Skip the data source references with empty data sources. This avoids data source reference with empty json for data sources
+
             app._dataSourceReferences = new Dictionary<string, LocalDatabaseReferenceJson>();
             foreach (var dataSourceReferenceEntry in dataSourceReferences)
             {
-                // if (dataSourceReferenceEntry.Value.dataSources.Count > 0 || dataSourceReferenceEntry.Value.ExtensionData.Count > 0)
-                // {
-                    app._dataSourceReferences.Add(dataSourceReferenceEntry);
-                // }
+                app._dataSourceReferences.Add(dataSourceReferenceEntry);
             }
 
             // key is filename, value is stringified xml


### PR DESCRIPTION
## Problem
Error on unpack with unused Dataverse data source

## Problem Area
-  Data source references with empty data sources were skipped.
- In some cases, data source can be empty, but the extension data is important and lost while unpacking causing the roundtrip to fail.
![image](https://user-images.githubusercontent.com/98551644/196540212-a6f05516-b1cd-4870-870a-96e15f099c1a.png)
 
## Solution
- Make sure LocalDatabaseRef contents are not lost while unpacking.
- Just save the LocalDatabaseRef as it is without skipping any content.

## Validation
- Roundtrip validation on user app
- Unit testing
- Stress test on all test apps successful