### PR TITLE
Updating Newtonsoft references to 13.0.2

### DIFF
--- a/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
+++ b/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
@@ -50,7 +50,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
     <PackageReference Include="YamlDotNet" Version="11.2.1" />

--- a/src/PAModelTests/PAModelTests.csproj
+++ b/src/PAModelTests/PAModelTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />


### PR DESCRIPTION
## Problem
Component Governance - NewtonSoft.Json 13.0.1 High Severity

## Solution
Upgrade NewtonSoft.Json version to 13.0.2

## Validation
Roundtrip testing (existing roundtrip testing on test apps)