### PR TITLE
Handling object reference not set GetResourcesJSONIndicesKey

### DIFF
--- a/src/PAModel/Entropy.cs
+++ b/src/PAModel/Entropy.cs
@@ -168,7 +168,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
         public void Add(ResourceJson resource, int order)
         {
-            if (resource != null)
+            if (resource == null)
             {
                 return;
             }

--- a/src/PAModel/Entropy.cs
+++ b/src/PAModel/Entropy.cs
@@ -170,7 +170,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         {
             if (resource == null)
             {
-                return;
+               return;
             }
 
             var key = GetResourcesJsonIndicesKey(resource);

--- a/src/PAModel/Entropy.cs
+++ b/src/PAModel/Entropy.cs
@@ -168,6 +168,11 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
         public void Add(ResourceJson resource, int order)
         {
+            if (resource != null)
+            {
+                return;
+            }
+
             var key = GetResourcesJsonIndicesKey(resource);
             if (!this.ResourcesJsonIndices.ContainsKey(key))
             {

--- a/src/PAModelTests/EntropyTests.cs
+++ b/src/PAModelTests/EntropyTests.cs
@@ -95,18 +95,8 @@ namespace PAModelTests
             (var msapp, var errors) = CanvasDocument.LoadFromMsapp(root);
             errors.ThrowOnErrors();
 
-            var resource1 = new ResourceJson()
-            {
-                Name = "Image1",
-                Path = "Assets\\Images\\Image.png",
-                FileName = "Image.png",
-                ResourceKind = ResourceKind.LocalFile,
-                Content = ContentKind.Image,
-            };
-            msapp._assetFiles.Add(new FilePath("Images", "Image.png"), new FileEntry());
-
             // passing null resource in resourcesJson
-            msapp._resourcesJson = new ResourcesJson() { Resources = new ResourceJson[] { resource1, null } };
+            msapp._resourcesJson = new ResourcesJson() { Resources = new ResourceJson[] { null } };
                         
             TranformResourceJson.PersistOrderingOfResourcesJsonEntries(msapp);
         }

--- a/src/PAModelTests/EntropyTests.cs
+++ b/src/PAModelTests/EntropyTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using Microsoft.PowerPlatform.Formulas.Tools;
+using Microsoft.PowerPlatform.Formulas.Tools.Schemas;
+using Microsoft.PowerPlatform.Formulas.Tools.Utility;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
@@ -81,6 +83,32 @@ namespace PAModelTests
 
             Assert.IsNotNull(msapp._entropy.OverridablePropertiesEntry);
             Assert.IsNotNull(msapp._entropy.PCFDynamicSchemaForIRRetrievalEntry);
+        }
+
+        [DataTestMethod]
+        [DataRow("AnimationControlIdIsGuid.msapp")]
+        public void TestGetResourcesJSONIndicesKeyNullException(string filename)
+        {
+            var root = Path.Combine(Environment.CurrentDirectory, "Apps", filename);
+            Assert.IsTrue(File.Exists(root));
+
+            (var msapp, var errors) = CanvasDocument.LoadFromMsapp(root);
+            errors.ThrowOnErrors();
+
+            var resource1 = new ResourceJson()
+            {
+                Name = "Image1",
+                Path = "Assets\\Images\\Image.png",
+                FileName = "Image.png",
+                ResourceKind = ResourceKind.LocalFile,
+                Content = ContentKind.Image,
+            };
+            msapp._assetFiles.Add(new FilePath("Images", "Image.png"), new FileEntry());
+
+            // passing null resource in resourcesJson
+            msapp._resourcesJson = new ResourcesJson() { Resources = new ResourceJson[] { resource1, null } };
+                        
+            TranformResourceJson.PersistOrderingOfResourcesJsonEntries(msapp);
         }
     }
 }


### PR DESCRIPTION
## Problem
Reported Issue : PA3001: Internal Error: Object Reference: GetResourcesJSONIndicesKey

"Error": **Unknown Error** 'Error   PA3001: Internal error. Object reference not set to an instance of an object.
Stack Trace:
   at Microsoft.PowerPlatform.Formulas.Tools.Entropy.GetResourcesJsonIndicesKey(ResourceJson resource)
   at Microsoft.PowerPlatform.Formulas.Tools.TranformResourceJson.PersistOrderingOfResourcesJsonEntries(CanvasDocument app)
   at Microsoft.PowerPlatform.Formulas.Tools.CanvasDocument.ApplyAfterMsAppLoadTransforms(ErrorContainer errors)
   at Microsoft.PowerPlatform.Formulas.Tools.MsAppSerializer.SaveAsMsApp(CanvasDocument app, String fullpathToMsApp, ErrorContainer errors, Boolean isValidation)',
"Count": 258

## Solution
Handle resource null case before Entropy.GetResourcesJsonIndicesKey()

## Validation
Roundtrip testing
