### PR TITLE
Templates in AppSerializer throwing NullRef

### DIFF
--- a/src/PAModel/Serializers/MsAppSerializer.cs
+++ b/src/PAModel/Serializers/MsAppSerializer.cs
@@ -238,27 +238,31 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                     }
                 } // foreach zip entry
 
-                foreach (var template in app._templates.UsedTemplates)
+                // If no templates exist
+                if (app._templates == null)
                 {
-                    if (app._templateStore.TryGetTemplate(template.Name, out var templateState))
+                    foreach (var template in app._templates.UsedTemplates)
                     {
-                        templateState.IsWidgetTemplate = true;
+                        if (app._templateStore.TryGetTemplate(template.Name, out var templateState))
+                        {
+                            templateState.IsWidgetTemplate = true;
+                        }
                     }
-                }
 
-                foreach (var componentTemplate in app._templates.ComponentTemplates ?? Enumerable.Empty<TemplateMetadataJson>())
-                {
-                    if (!app._templateStore.TryGetTemplate(componentTemplate.Name, out var template))
-                        continue;
-                    template.TemplateOriginalName = componentTemplate.OriginalName;
-                    template.IsComponentLocked = componentTemplate.IsComponentLocked;
-                    template.ComponentChangedSinceFileImport = componentTemplate.ComponentChangedSinceFileImport;
-                    template.ComponentAllowCustomization = componentTemplate.ComponentAllowCustomization;
-                    template.ComponentExtraMetadata = componentTemplate.ExtensionData;
-
-                    if (template.Version != componentTemplate.Version)
+                    foreach (var componentTemplate in app._templates.ComponentTemplates ?? Enumerable.Empty<TemplateMetadataJson>())
                     {
-                        app._entropy.SetTemplateVersion(template.Name, componentTemplate.Version);
+                        if (!app._templateStore.TryGetTemplate(componentTemplate.Name, out var template))
+                            continue;
+                        template.TemplateOriginalName = componentTemplate.OriginalName;
+                        template.IsComponentLocked = componentTemplate.IsComponentLocked;
+                        template.ComponentChangedSinceFileImport = componentTemplate.ComponentChangedSinceFileImport;
+                        template.ComponentAllowCustomization = componentTemplate.ComponentAllowCustomization;
+                        template.ComponentExtraMetadata = componentTemplate.ExtensionData;
+
+                        if (template.Version != componentTemplate.Version)
+                        {
+                            app._entropy.SetTemplateVersion(template.Name, componentTemplate.Version);
+                        }
                     }
                 }
 

--- a/src/PAModel/Serializers/MsAppSerializer.cs
+++ b/src/PAModel/Serializers/MsAppSerializer.cs
@@ -239,7 +239,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 } // foreach zip entry
 
                 // If no templates exist
-                if (app._templates == null)
+                if (app._templates != null)
                 {
                     foreach (var template in app._templates.UsedTemplates)
                     {


### PR DESCRIPTION
## Problem

Null Reference made in AppSerializer when iterating through templates.

## Solution

Check if templates are null; do not execute that code if so.

## Changes

## Validation

- Create Unit Test
