### PR TITLE
Resolving multiple NullRef errors

### DIFF
--- a/src/PAModel/Entropy.cs
+++ b/src/PAModel/Entropy.cs
@@ -225,18 +225,20 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
         public void SetProperties(DocumentPropertiesJson documentProperties)
         {
-            VolatileProperties = new PropertyEntropy()
-            {
-                AnalysisLoadTime = documentProperties.AnalysisLoadTime,
-                DeserializationLoadTime = documentProperties.DeserializationLoadTime,
-                ControlCount = documentProperties.ControlCount,
-                ErrorCount = documentProperties.ErrorCount
-            };
+            if (documentProperties != null) {
+                VolatileProperties = new PropertyEntropy()
+                {
+                    AnalysisLoadTime = documentProperties.AnalysisLoadTime,
+                    DeserializationLoadTime = documentProperties.DeserializationLoadTime,
+                    ControlCount = documentProperties.ControlCount,
+                    ErrorCount = documentProperties.ErrorCount
+                };
 
-            documentProperties.AnalysisLoadTime = null;
-            documentProperties.DeserializationLoadTime = null;
-            documentProperties.ControlCount = null;
-            documentProperties.ErrorCount = null;
+                documentProperties.AnalysisLoadTime = null;
+                documentProperties.DeserializationLoadTime = null;
+                documentProperties.ControlCount = null;
+                documentProperties.ErrorCount = null;
+            }
         }
 
         public void GetProperties(DocumentPropertiesJson documentProperties)

--- a/src/PAModel/Serializers/MsAppSerializer.cs
+++ b/src/PAModel/Serializers/MsAppSerializer.cs
@@ -238,31 +238,27 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                     }
                 } // foreach zip entry
 
-                // If no templates exist
-                if (app._templates != null)
+                foreach (var template in app._templates.UsedTemplates)
                 {
-                    foreach (var template in app._templates.UsedTemplates)
+                    if (app._templateStore.TryGetTemplate(template.Name, out var templateState))
                     {
-                        if (app._templateStore.TryGetTemplate(template.Name, out var templateState))
-                        {
-                            templateState.IsWidgetTemplate = true;
-                        }
+                        templateState.IsWidgetTemplate = true;
                     }
+                }
 
-                    foreach (var componentTemplate in app._templates.ComponentTemplates ?? Enumerable.Empty<TemplateMetadataJson>())
+                foreach (var componentTemplate in app._templates.ComponentTemplates ?? Enumerable.Empty<TemplateMetadataJson>())
+                {
+                    if (!app._templateStore.TryGetTemplate(componentTemplate.Name, out var template))
+                        continue;
+                    template.TemplateOriginalName = componentTemplate.OriginalName;
+                    template.IsComponentLocked = componentTemplate.IsComponentLocked;
+                    template.ComponentChangedSinceFileImport = componentTemplate.ComponentChangedSinceFileImport;
+                    template.ComponentAllowCustomization = componentTemplate.ComponentAllowCustomization;
+                    template.ComponentExtraMetadata = componentTemplate.ExtensionData;
+
+                    if (template.Version != componentTemplate.Version)
                     {
-                        if (!app._templateStore.TryGetTemplate(componentTemplate.Name, out var template))
-                            continue;
-                        template.TemplateOriginalName = componentTemplate.OriginalName;
-                        template.IsComponentLocked = componentTemplate.IsComponentLocked;
-                        template.ComponentChangedSinceFileImport = componentTemplate.ComponentChangedSinceFileImport;
-                        template.ComponentAllowCustomization = componentTemplate.ComponentAllowCustomization;
-                        template.ComponentExtraMetadata = componentTemplate.ExtensionData;
-
-                        if (template.Version != componentTemplate.Version)
-                        {
-                            app._entropy.SetTemplateVersion(template.Name, componentTemplate.Version);
-                        }
+                        app._entropy.SetTemplateVersion(template.Name, componentTemplate.Version);
                     }
                 }
 
@@ -306,17 +302,15 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 // Normalize logo filename. 
                 app.TranformLogoOnLoad();
 
-                if (app._properties != null) {
-                    if (!string.IsNullOrEmpty(app._properties.LibraryDependencies))
-                    {
-                        var refs = Utilities.JsonParse<ComponentDependencyInfo[]>(app._properties.LibraryDependencies);
-                        app._libraryReferences = refs;
-                        app._properties.LibraryDependencies = null;
-                    }
-                
+                if (!string.IsNullOrEmpty(app._properties.LibraryDependencies))
+                {
+                    var refs = Utilities.JsonParse<ComponentDependencyInfo[]>(app._properties.LibraryDependencies);
+                    app._libraryReferences = refs;
+                    app._properties.LibraryDependencies = null;
+                }
 
-                    if (!string.IsNullOrEmpty(app._properties.LocalConnectionReferences))
-                    {
+                if (!string.IsNullOrEmpty(app._properties.LocalConnectionReferences))
+                {
                     var cxs = Utilities.JsonParse<IDictionary<String, ConnectionJson>>(app._properties.LocalConnectionReferences);
 
                     foreach (var connectionJson in cxs)
@@ -336,36 +330,35 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                             }
                         }
                     }
-                        app._connections = cxs;
-                        app._properties.LocalConnectionReferences = null;
 
-                    }
-
-
-                    app._entropy.WasLocalDatabaseReferencesEmpty = true;
-                    if (string.IsNullOrEmpty(app._properties.LocalDatabaseReferences))
-                    {
-                        app._entropy.LocalDatabaseReferencesAsEmpty = true;
-                    }
-                    else
-                    {
-                        var dsrs = Utilities.JsonParse<IDictionary<string, LocalDatabaseReferenceJson>>(app._properties.LocalDatabaseReferences);
-                        app._entropy.LocalDatabaseReferencesAsEmpty = false;
-                        if (dsrs.Count > 0)
-                        {
-                            app._entropy.WasLocalDatabaseReferencesEmpty = false;
-                            app._dataSourceReferences = dsrs;
-                            app._properties.LocalDatabaseReferences = null;
-                        }
-                    }
-
-                    if (!string.IsNullOrEmpty(app._properties.InstrumentationKey))
-                    {
-                        app._appInsights = new AppInsightsKeyJson() { InstrumentationKey = app._properties.InstrumentationKey };
-                        app._properties.InstrumentationKey = null;
-                    }
-
+                    app._connections = cxs;
+                    app._properties.LocalConnectionReferences = null;
                 }
+
+                app._entropy.WasLocalDatabaseReferencesEmpty = true;
+                if (string.IsNullOrEmpty(app._properties.LocalDatabaseReferences))
+                {
+                    app._entropy.LocalDatabaseReferencesAsEmpty = true;
+                }
+                else
+                {
+                    var dsrs = Utilities.JsonParse<IDictionary<string, LocalDatabaseReferenceJson>>(app._properties.LocalDatabaseReferences);
+                    app._entropy.LocalDatabaseReferencesAsEmpty = false;
+                    if (dsrs.Count > 0)
+                    {
+                        app._entropy.WasLocalDatabaseReferencesEmpty = false;
+                        app._dataSourceReferences = dsrs;
+                        app._properties.LocalDatabaseReferences = null;
+                    }
+                }
+
+                if (!string.IsNullOrEmpty(app._properties.InstrumentationKey))
+                {
+                    app._appInsights = new AppInsightsKeyJson() { InstrumentationKey = app._properties.InstrumentationKey };
+                    app._properties.InstrumentationKey = null;
+                }
+
+
                 if (componentsMetadata?.Components != null)
                 {
                     int order = 0;

--- a/src/PAModel/Serializers/MsAppSerializer.cs
+++ b/src/PAModel/Serializers/MsAppSerializer.cs
@@ -306,15 +306,17 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 // Normalize logo filename. 
                 app.TranformLogoOnLoad();
 
-                if (!string.IsNullOrEmpty(app._properties.LibraryDependencies))
-                {
-                    var refs = Utilities.JsonParse<ComponentDependencyInfo[]>(app._properties.LibraryDependencies);
-                    app._libraryReferences = refs;
-                    app._properties.LibraryDependencies = null;
-                }
+                if (app._properties != null) {
+                    if (!string.IsNullOrEmpty(app._properties.LibraryDependencies))
+                    {
+                        var refs = Utilities.JsonParse<ComponentDependencyInfo[]>(app._properties.LibraryDependencies);
+                        app._libraryReferences = refs;
+                        app._properties.LibraryDependencies = null;
+                    }
+                
 
-                if (!string.IsNullOrEmpty(app._properties.LocalConnectionReferences))
-                {
+                    if (!string.IsNullOrEmpty(app._properties.LocalConnectionReferences))
+                    {
                     var cxs = Utilities.JsonParse<IDictionary<String, ConnectionJson>>(app._properties.LocalConnectionReferences);
 
                     foreach (var connectionJson in cxs)
@@ -334,35 +336,36 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                             }
                         }
                     }
+                        app._connections = cxs;
+                        app._properties.LocalConnectionReferences = null;
 
-                    app._connections = cxs;
-                    app._properties.LocalConnectionReferences = null;
-                }
-
-                app._entropy.WasLocalDatabaseReferencesEmpty = true;
-                if (string.IsNullOrEmpty(app._properties.LocalDatabaseReferences))
-                {
-                    app._entropy.LocalDatabaseReferencesAsEmpty = true;
-                }
-                else
-                {
-                    var dsrs = Utilities.JsonParse<IDictionary<string, LocalDatabaseReferenceJson>>(app._properties.LocalDatabaseReferences);
-                    app._entropy.LocalDatabaseReferencesAsEmpty = false;
-                    if (dsrs.Count > 0)
-                    {
-                        app._entropy.WasLocalDatabaseReferencesEmpty = false;
-                        app._dataSourceReferences = dsrs;
-                        app._properties.LocalDatabaseReferences = null;
                     }
+
+
+                    app._entropy.WasLocalDatabaseReferencesEmpty = true;
+                    if (string.IsNullOrEmpty(app._properties.LocalDatabaseReferences))
+                    {
+                        app._entropy.LocalDatabaseReferencesAsEmpty = true;
+                    }
+                    else
+                    {
+                        var dsrs = Utilities.JsonParse<IDictionary<string, LocalDatabaseReferenceJson>>(app._properties.LocalDatabaseReferences);
+                        app._entropy.LocalDatabaseReferencesAsEmpty = false;
+                        if (dsrs.Count > 0)
+                        {
+                            app._entropy.WasLocalDatabaseReferencesEmpty = false;
+                            app._dataSourceReferences = dsrs;
+                            app._properties.LocalDatabaseReferences = null;
+                        }
+                    }
+
+                    if (!string.IsNullOrEmpty(app._properties.InstrumentationKey))
+                    {
+                        app._appInsights = new AppInsightsKeyJson() { InstrumentationKey = app._properties.InstrumentationKey };
+                        app._properties.InstrumentationKey = null;
+                    }
+
                 }
-
-                if (!string.IsNullOrEmpty(app._properties.InstrumentationKey))
-                {
-                    app._appInsights = new AppInsightsKeyJson() { InstrumentationKey = app._properties.InstrumentationKey };
-                    app._properties.InstrumentationKey = null;
-                }
-
-
                 if (componentsMetadata?.Components != null)
                 {
                     int order = 0;

--- a/src/PAModel/Serializers/MsAppSerializer.cs
+++ b/src/PAModel/Serializers/MsAppSerializer.cs
@@ -238,27 +238,31 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                     }
                 } // foreach zip entry
 
-                foreach (var template in app._templates.UsedTemplates)
+                // If no templates exist
+                if (app._templates == null)
                 {
-                    if (app._templateStore.TryGetTemplate(template.Name, out var templateState))
+                    foreach (var template in app._templates.UsedTemplates)
                     {
-                        templateState.IsWidgetTemplate = true;
+                        if (app._templateStore.TryGetTemplate(template.Name, out var templateState))
+                        {
+                            templateState.IsWidgetTemplate = true;
+                        }
                     }
-                }
 
-                foreach (var componentTemplate in app._templates.ComponentTemplates ?? Enumerable.Empty<TemplateMetadataJson>())
-                {
-                    if (!app._templateStore.TryGetTemplate(componentTemplate.Name, out var template))
-                        continue;
-                    template.TemplateOriginalName = componentTemplate.OriginalName;
-                    template.IsComponentLocked = componentTemplate.IsComponentLocked;
-                    template.ComponentChangedSinceFileImport = componentTemplate.ComponentChangedSinceFileImport;
-                    template.ComponentAllowCustomization = componentTemplate.ComponentAllowCustomization;
-                    template.ComponentExtraMetadata = componentTemplate.ExtensionData;
-
-                    if (template.Version != componentTemplate.Version)
+                    foreach (var componentTemplate in app._templates.ComponentTemplates ?? Enumerable.Empty<TemplateMetadataJson>())
                     {
-                        app._entropy.SetTemplateVersion(template.Name, componentTemplate.Version);
+                        if (!app._templateStore.TryGetTemplate(componentTemplate.Name, out var template))
+                            continue;
+                        template.TemplateOriginalName = componentTemplate.OriginalName;
+                        template.IsComponentLocked = componentTemplate.IsComponentLocked;
+                        template.ComponentChangedSinceFileImport = componentTemplate.ComponentChangedSinceFileImport;
+                        template.ComponentAllowCustomization = componentTemplate.ComponentAllowCustomization;
+                        template.ComponentExtraMetadata = componentTemplate.ExtensionData;
+
+                        if (template.Version != componentTemplate.Version)
+                        {
+                            app._entropy.SetTemplateVersion(template.Name, componentTemplate.Version);
+                        }
                     }
                 }
 

--- a/src/PAModel/Serializers/MsAppSerializer.cs
+++ b/src/PAModel/Serializers/MsAppSerializer.cs
@@ -239,7 +239,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 } // foreach zip entry
 
                 // If no templates exist
-                if (app._templates == null)
+                if (app._templates != null)
                 {
                     foreach (var template in app._templates.UsedTemplates)
                     {

--- a/src/PAModel/Serializers/TransformLogo.cs
+++ b/src/PAModel/Serializers/TransformLogo.cs
@@ -18,24 +18,26 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
     {
         public static void TranformLogoOnLoad(this CanvasDocument app)
         {
-            // May be null or "" 
-            var oldLogoName = app._publishInfo.LogoFileName;
-            if (!string.IsNullOrEmpty(oldLogoName))
-            {
-                string newLogoName = "logo" + Path.GetExtension(oldLogoName);
-
-                FileEntry logoFile;
-                var oldKey = FilePath.RootedAt("Resources", FilePath.FromMsAppPath(oldLogoName));
-                if (app._unknownFiles.TryGetValue(oldKey, out logoFile))
+            if (app._publishInfo != null) {
+                // May be null or "" 
+                var oldLogoName = app._publishInfo.LogoFileName;
+                if (!string.IsNullOrEmpty(oldLogoName))
                 {
-                    app._unknownFiles.Remove(oldKey);
+                    string newLogoName = "logo" + Path.GetExtension(oldLogoName);
 
-                    logoFile.Name = new FilePath(newLogoName);
-                    app._logoFile = logoFile;
+                    FileEntry logoFile;
+                    var oldKey = FilePath.RootedAt("Resources", FilePath.FromMsAppPath(oldLogoName));
+                    if (app._unknownFiles.TryGetValue(oldKey, out logoFile))
+                    {
+                        app._unknownFiles.Remove(oldKey);
+
+                        logoFile.Name = new FilePath(newLogoName);
+                        app._logoFile = logoFile;
 
 
-                    app._entropy.SetLogoFileName(oldLogoName);
-                    app._publishInfo.LogoFileName = newLogoName;
+                        app._entropy.SetLogoFileName(oldLogoName);
+                        app._publishInfo.LogoFileName = newLogoName;
+                    }
                 }
             }
         }

--- a/src/PAModel/Serializers/TransformResourceJson.cs
+++ b/src/PAModel/Serializers/TransformResourceJson.cs
@@ -32,9 +32,11 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         /// <param name="app">The app.</param>
         public static void PersistOrderingOfResourcesJsonEntries(this CanvasDocument app)
         {
-            for (var i = 0; i < app._resourcesJson.Resources.Length; i++)
-            {
-                app._entropy.Add(app._resourcesJson.Resources[i], i);
+            if (app._resourcesJson != null) {
+                for (var i = 0; i < app._resourcesJson.Resources.Length; i++)
+                {
+                    app._entropy.Add(app._resourcesJson.Resources[i], i);
+                }
             }
         }
 

--- a/src/PAModel/Themes/Theme.cs
+++ b/src/PAModel/Themes/Theme.cs
@@ -18,18 +18,18 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
     {
         // Outer key is stylename, inner key is property name, inner value is expression
         private readonly Dictionary<string, Dictionary<string, string>> _styles = new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
-        
+
         public Theme(ThemesJson themeJson)
         {
-            Contract.Assert(themeJson != null);
-
-            var currentThemeName = themeJson.CurrentTheme;
-            var namedThemes = themeJson.CustomThemes.ToDictionary(theme => theme.name);
-            if (namedThemes.TryGetValue(currentThemeName, out var foundTheme))
-            {
-                LoadTheme(foundTheme);
+            if (themeJson != null)
+            { 
+                var currentThemeName = themeJson.CurrentTheme;
+                var namedThemes = themeJson.CustomThemes.ToDictionary(theme => theme.name);
+                if (namedThemes.TryGetValue(currentThemeName, out var foundTheme))
+                {
+                    LoadTheme(foundTheme);
+                }
             }
-            
         }
 
 


### PR DESCRIPTION
## Problem

Resolving several 'Object Reference not set to an instance of an object' issues:
- _templates in AppSerializer was not being checked if null
- _publishInfo in TransformLogo was not being checked if null
- _properties in AppSerializer was not being checked if null
- _resourcesJson in CanvasDocument was not being checked if null
- ThemesJson's Assert check was not actually preventing ThemesJson from being null
- documentProperties passed in func in Entropy was not being checked for null

## Solution
- Make sure code checks for items that could be null, before querying them.
-  Should all of these be allowed as null? If not, we can add additional Integrity Checks section of OnLoadComplete() in Canvas Document

## Validation

- Add unit testing
