### PR TITLE
Handling PCF template data separately for each PCF control instance

### DIFF
--- a/src/PAModel/Entropy.cs
+++ b/src/PAModel/Entropy.cs
@@ -107,6 +107,9 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         // Key is control name, value is PCFDynamicSchemaForIRRetrieval
         public Dictionary<string, object> PCFDynamicSchemaForIRRetrievalEntry { get; set; } = new Dictionary<string, object>(StringComparer.Ordinal);
 
+        // Key is control name, value is PCFTemplateDetails
+        public Dictionary<string, ControlInfoJson.Template> PCFTemplateDetailsEntry { get; set; } = new Dictionary<string, ControlInfoJson.Template>(StringComparer.Ordinal);
+
         public int GetOrder(DataSourceEntry dataSource)
         {
             // To ensure that that TableDefinitions are put at the end in DataSources.json when the order information is not available.

--- a/src/PAModel/Entropy.cs
+++ b/src/PAModel/Entropy.cs
@@ -108,7 +108,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         public Dictionary<string, object> PCFDynamicSchemaForIRRetrievalEntry { get; set; } = new Dictionary<string, object>(StringComparer.Ordinal);
 
         // Key is control name, value is PCFTemplateDetails
-        public Dictionary<string, ControlInfoJson.Template> PCFTemplateDetailsEntry { get; set; } = new Dictionary<string, ControlInfoJson.Template>(StringComparer.Ordinal);
+        public Dictionary<string, ControlInfoJson.Template> PCFTemplateEntry { get; set; } = new Dictionary<string, ControlInfoJson.Template>(StringComparer.Ordinal);
 
         public int GetOrder(DataSourceEntry dataSource)
         {

--- a/src/PAModel/IR/IRStateHelpers.cs
+++ b/src/PAModel/IR/IRStateHelpers.cs
@@ -203,7 +203,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             // Control Instance 2 -> pcftemplate1 -> DynamicControlDefinitionJson2
             if (IsPCFControl(control.Template))
             {
-                entropy.PCFTemplateDetailsEntry.Add(control.Name, control.Template);
+                entropy.PCFTemplateEntry.Add(control.Name, control.Template);
             }
 
             if (templateStore.TryGetTemplate(control.Template.Name, out var templateState))
@@ -313,7 +313,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             }
             else
             {
-                if (templateState.IsPcfControl && entropy.PCFTemplateDetailsEntry.TryGetValue(controlName, out var PCFTemplate))
+                if (templateState.IsPcfControl && entropy.PCFTemplateEntry.TryGetValue(controlName, out var PCFTemplate))
                 {
                     template = PCFTemplate;
                 }

--- a/src/PAModel/IR/IRStateHelpers.cs
+++ b/src/PAModel/IR/IRStateHelpers.cs
@@ -205,8 +205,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             {
                 entropy.PCFTemplateEntry.Add(control.Name, control.Template);
             }
-
-            if (templateStore.TryGetTemplate(control.Template.Name, out var templateState))
+            else if (templateStore.TryGetTemplate(control.Template.Name, out var templateState))
             {
                 if (isComponentDef)
                 {
@@ -307,20 +306,19 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             var orderedChildren = children.OrderBy(childPair => childPair.index).Select(pair => pair.item).ToArray();
 
             ControlInfoJson.Template template;
-            if (!templateStore.TryGetTemplate(templateName, out var templateState))
+            CombinedTemplateState templateState;
+            if (entropy.PCFTemplateEntry.TryGetValue(controlName, out var PCFTemplate))
+            {
+                template = PCFTemplate;
+                templateState = new CombinedTemplateState(PCFTemplate);
+            }
+            else if (!templateStore.TryGetTemplate(templateName, out templateState))
             {
                 template = ControlInfoJson.Template.CreateDefaultTemplate(templateName, null);
             }
             else
             {
-                if (templateState.IsPcfControl && entropy.PCFTemplateEntry.TryGetValue(controlName, out var PCFTemplate))
-                {
-                    template = PCFTemplate;
-                }
-                else
-                {
-                    template = templateState.ToControlInfoTemplate();
-                }                
+                template = templateState.ToControlInfoTemplate();
             }
 
             RecombineCustomTemplates(entropy, template, controlName);

--- a/src/PAModelTests/EntropyTests.cs
+++ b/src/PAModelTests/EntropyTests.cs
@@ -81,8 +81,8 @@ namespace PAModelTests
             (var msapp, var errors) = CanvasDocument.LoadFromMsapp(root);
             errors.ThrowOnErrors();
 
-            Assert.IsNotNull(msapp._entropy.OverridablePropertiesEntry);
-            Assert.IsNotNull(msapp._entropy.PCFDynamicSchemaForIRRetrievalEntry);
+            Assert.IsNotNull(msapp._entropy.OverridablePropertiesEntry.Count > 0);
+            Assert.IsNotNull(msapp._entropy.PCFDynamicSchemaForIRRetrievalEntry.Count > 0);
         }
 
         [DataTestMethod]
@@ -99,6 +99,21 @@ namespace PAModelTests
             msapp._resourcesJson = new ResourcesJson() { Resources = new ResourceJson[] { null } };
                         
             TranformResourceJson.PersistOrderingOfResourcesJsonEntries(msapp);
+        }
+
+        // Validate that the pcf control template is stored in entropy while unpacking
+        // The test app contains control instances with same template but different fields
+        [DataTestMethod]
+        [DataRow("PcfTemplates.msapp")]
+        public void TestPCFControlInstancesWithSameTemplateDifferentFields(string appName)
+        {
+            var root = Path.Combine(Environment.CurrentDirectory, "Apps", appName);
+            Assert.IsTrue(File.Exists(root));
+
+            (var msapp, var errors) = CanvasDocument.LoadFromMsapp(root);
+            errors.ThrowOnErrors();
+
+            Assert.IsNotNull(msapp._entropy.PCFTemplateDetailsEntry.Count > 0);
         }
     }
 }

--- a/src/PAModelTests/EntropyTests.cs
+++ b/src/PAModelTests/EntropyTests.cs
@@ -81,8 +81,8 @@ namespace PAModelTests
             (var msapp, var errors) = CanvasDocument.LoadFromMsapp(root);
             errors.ThrowOnErrors();
 
-            Assert.IsNotNull(msapp._entropy.OverridablePropertiesEntry.Count > 0);
-            Assert.IsNotNull(msapp._entropy.PCFDynamicSchemaForIRRetrievalEntry.Count > 0);
+            Assert.IsTrue(msapp._entropy.OverridablePropertiesEntry.Count > 0);
+            Assert.IsTrue(msapp._entropy.PCFDynamicSchemaForIRRetrievalEntry.Count > 0);
         }
 
         [DataTestMethod]
@@ -113,7 +113,20 @@ namespace PAModelTests
             (var msapp, var errors) = CanvasDocument.LoadFromMsapp(root);
             errors.ThrowOnErrors();
 
-            Assert.IsNotNull(msapp._entropy.PCFTemplateEntry.Count > 0);
+            Assert.IsTrue(msapp._entropy.PCFTemplateEntry.Count > 0);
+        }
+
+        [DataTestMethod]
+        [DataRow("AnimationControlIdIsGuid.msapp")]
+        public void TestAppWithNoPCFControlInstances(string appName)
+        {
+            var root = Path.Combine(Environment.CurrentDirectory, "Apps", appName);
+            Assert.IsTrue(File.Exists(root));
+
+            (var msapp, var errors) = CanvasDocument.LoadFromMsapp(root);
+            errors.ThrowOnErrors();
+
+            Assert.IsTrue(msapp._entropy.PCFTemplateEntry.Count == 0);
         }
     }
 }

--- a/src/PAModelTests/EntropyTests.cs
+++ b/src/PAModelTests/EntropyTests.cs
@@ -113,7 +113,7 @@ namespace PAModelTests
             (var msapp, var errors) = CanvasDocument.LoadFromMsapp(root);
             errors.ThrowOnErrors();
 
-            Assert.IsNotNull(msapp._entropy.PCFTemplateDetailsEntry.Count > 0);
+            Assert.IsNotNull(msapp._entropy.PCFTemplateEntry.Count > 0);
         }
     }
 }


### PR DESCRIPTION
## Problem
- Different control instances could have different template data even if they appear to follow same template.
- Like version, DynamicControlDefinitionJSON etc could be different.
``` 
Eg: Control Instance 1 -> pcftemplate1 -> DynamicControlDefinitionJson1
      Control Instance 2 -> pcftemplate1 -> DynamicControlDefinitionJson2
```
- This causes roundtrip errors like below
<img width="1192" alt="image" src="https://user-images.githubusercontent.com/98551644/221709349-dcce2b79-249c-4e85-8804-3e289a130691.png">

## Solution
- Make use of entropy data and create a new dictionary to store/retrieve PCF template data
- Store PCFtemplate separately while unpacking >>> ` IRStateHelpers.SplitIRAndState()`
- Retrieve the stored PCFtemplate data while packing >>> `IRStateHelpers.CombineIRAndState()`
- This will avoid such roundtrip errors

## Validation
- UnitTesting
