### PR TITLE
Fix PCF template storage

### DIFF
--- a/src/PAModel/IR/IRStateHelpers.cs
+++ b/src/PAModel/IR/IRStateHelpers.cs
@@ -197,15 +197,17 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                 entropy.OverridablePropertiesEntry.Add(control.Name, OverridablePropVal);
             }
 
-            // Storing pcf controls template data in entropy
+            // Store PCF control template data in entropy, per control.
             // Since this could be different for different controls, even if that appear to follow the same template
             // Eg:Control Instance 1 -> pcftemplate1 -> DynamicControlDefinitionJson1
             // Control Instance 2 -> pcftemplate1 -> DynamicControlDefinitionJson2
+            // A copy of the template will also be kept in the template store, in case entropy data is lost.
             if (IsPCFControl(control.Template))
             {
                 entropy.PCFTemplateEntry.Add(control.Name, control.Template);
             }
-            else if (templateStore.TryGetTemplate(control.Template.Name, out var templateState))
+
+            if (templateStore.TryGetTemplate(control.Template.Name, out var templateState))
             {
                 if (isComponentDef)
                 {
@@ -307,6 +309,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
             ControlInfoJson.Template template;
             CombinedTemplateState templateState;
+
+            // Prefer the specific PCF template for the control, if available. Otherwise, try to fall back to the template store.
             if (entropy.PCFTemplateEntry.TryGetValue(controlName, out var PCFTemplate))
             {
                 template = PCFTemplate;


### PR DESCRIPTION
## Problem

The way PCF templates are stored was changed so that each control's specific template is stored in a new field in `Entropy.json`. This was done to resolve an issue where differing versions of the same control type would incorrectly use the same template.

Since `Entropy.json` should technically only contain fields which are optional, this introduced an issue where an empty `Entropy.json` would mean that the entire PCF template would be missing when restoring the `.msapp`. This change will keep a copy of the PCF template in the template store as well, as a fall back in case it cannot be found on a per-PCF control basis.

## Validation

This is challenging to validate, because it isn't easily caught in round-trip testing, as it involves the `Entropy.json` file being modified between the unpack and pack. I've validated this manually, and the existing tests should ensure that other scenarios are not impacted.

I've also added a new unit test to validate the fallback to the template store. This test fails prior to my change.