### PR TITLE
Fixing build badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![image](https://img.shields.io/github/workflow/status/microsoft/PowerApps-Language-Tooling/CI/master)  ![image](https://img.shields.io/nuget/vpre/Microsoft.PowerPlatform.Formulas.Tools)
+![image](https://img.shields.io/github/actions/workflow/status/microsoft/PowerApps-Language-Tooling/CI/master/CI.yml?branch=master)  ![image](https://img.shields.io/nuget/vpre/Microsoft.PowerPlatform.Formulas.Tools)
 
 # Power Apps Source File Pack and Unpack Utility
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![image](https://img.shields.io/github/actions/workflow/status/microsoft/PowerApps-Language-Tooling/CI/master/CI.yml?branch=master)  ![image](https://img.shields.io/nuget/vpre/Microsoft.PowerPlatform.Formulas.Tools)
+![image](https://img.shields.io/github/actions/workflow/status/microsoft/PowerApps-Language-Tooling/CI.yml?branch=master)  ![image](https://img.shields.io/nuget/vpre/Microsoft.PowerPlatform.Formulas.Tools)
 
 # Power Apps Source File Pack and Unpack Utility
 


### PR DESCRIPTION
Previous badge for status of the build:
![image](https://user-images.githubusercontent.com/71468580/234316718-6382bbcf-5615-4018-8720-4ca57d0a09d3.png)

Which links to: https://github.com/badges/shields/issues/8671

Resolved badge:
![image](https://user-images.githubusercontent.com/71468580/234316952-95898bb9-c181-495a-9f9d-0d3642947749.png)
