### PR TITLE
Updated dotnet SDK to 6.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,9 +21,11 @@ jobs:
       with:
         lfs: true
 
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '3.1.x'
+        dotnet-version: | 
+          3.1.x
+          6.0.x
 
     - run: dotnet --info
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.404",
+    "version": "6.0.0",
     "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
If this is related to an issue open in GitHub, please link it to this ticket and put the URL here.

## Problem

Unable to build with supported versions of DotNet SDK

## Solution

Update from 3.0 to 6.0 (LTS)

Supported versions are 6.0, 7.0, 8.0
https://dotnet.microsoft.com/en-us/download/visual-studio-sdks

## Validation

Successful build and run
