### PR TITLE
Update Azure Pipeline to Dotnet SDK 6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,21 @@ This is similar to the [Solution Packager](https://docs.microsoft.com/en-us/powe
 
 To get started, download and install the [Microsoft Power Platform CLI](https://docs.microsoft.com/en-us/powerapps/developer/data-platform/powerapps-cli).
 
-Easiest way to get pac cli is to use dotnet tool install: `dotnet tool install -g Microsoft.PowerPlatform.Cli`
+Easiest way to get pac cli is to use [dotnet tool install](https://www.nuget.org/packages/Microsoft.PowerApps.CLI.Tool):
 
-To unpack a .msapp file: `pac canvas unpack --msapp FromApp.msapp --sources ToSourceFolder`
-To pack a .msapp file: `pac canvas pack --msapp ToApp.msapp --sources FromSourceFolder`
+```
+dotnet tool install --global Microsoft.PowerApps.CLI.Tool
+```
+
+To unpack a .msapp file:
+```
+pac canvas unpack --msapp FromApp.msapp --sources ToSourceFolder
+```
+
+To pack a .msapp file:
+```
+pac canvas pack --msapp ToApp.msapp --sources FromSourceFolder
+```
 
 ### Versioning
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ This is similar to the [Solution Packager](https://docs.microsoft.com/en-us/powe
 
 To get started, download and install the [Microsoft Power Platform CLI](https://docs.microsoft.com/en-us/powerapps/developer/data-platform/powerapps-cli).
 
+Easiest way to get pac cli is to use dotnet tool install: `dotnet tool install -g Microsoft.PowerPlatform.Cli`
+
 To unpack a .msapp file: `pac canvas unpack --msapp FromApp.msapp --sources ToSourceFolder`
 To pack a .msapp file: `pac canvas pack --msapp ToApp.msapp --sources FromSourceFolder`
 
@@ -41,7 +43,7 @@ Latest Yaml version is: https://github.com/microsoft/PowerApps-Language-Tooling/
 
 You can also use this functionality stand alone, using our test console app.
 
-Download and install the [.NET Core SDK v3.1.x (x64)](https://dotnet.microsoft.com/download/dotnet-core/3.1) in order to build.
+Download and install the [.NET Core SDK v6.0.x (x64)](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) in order to build.
 Build the test console app by running: `\build.cmd`
 This will create: `\bin\Debug\PASopa\PASopa.exe`
 
@@ -111,9 +113,9 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 For a developer machine (Windows 10, WSL, Linux, macOS), install:
 
 - [git](https://git-scm.com/downloads)
-- [.NET Core SDK v3.1.x (x64)](https://dotnet.microsoft.com/download/dotnet-core/3.1)
+- [.NET Core SDK v6.0.x (x64)](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
 - [VS Code](https://code.visualstudio.com/Download)
-- if on Windows: [VS2019 (Community edition will do)](https://visualstudio.microsoft.com/downloads/).  Select at least the following workload: .NET Core cross-plat
+- if on Windows: [VS2019 or VS2022 (Community edition will do)](https://visualstudio.microsoft.com/downloads/).  Select at least the following workload: .NET Core cross-plat
 - recommended VSCode extensions:
   - [GitLens (eamodio.gitlens)](https://github.com/eamodio/vscode-gitlens)
   - [C# (ms-vscode.csharp)](https://github.com/OmniSharp/omnisharp-vscode)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,6 @@ jobs:
       installationPath: '$(Agent.ToolsDirectory)/dotnet'
 
   - task: UseDotNet@2
-  - task: UseDotNet@2
     displayName: 'Use dotnet sdk 3.1'
     inputs:
       version: 3.1.x

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,6 +29,13 @@ jobs:
       version: 6.0.x
       installationPath: '$(Agent.ToolsDirectory)/dotnet'
 
+  - task: UseDotNet@2
+  - task: UseDotNet@2
+    displayName: 'Use dotnet sdk 3.1'
+    inputs:
+      version: 3.1.x
+      installationPath: '$(Agent.ToolsDirectory)/dotnet'
+
   # Dotnet 2.1 appears to be required for ESRP signing
   - task: UseDotNet@2
     displayName: 'Use dotnet sdk 2.1'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,9 +24,9 @@ jobs:
 
   steps:
   - task: UseDotNet@2
-    displayName: 'Use dotnet sdk 3.1'
+    displayName: 'Use dotnet SDK 6.0'
     inputs:
-      version: 3.1.x
+      version: 6.0.x
       installationPath: '$(Agent.ToolsDirectory)/dotnet'
 
   # Dotnet 2.1 appears to be required for ESRP signing

--- a/src/PAModel/Schemas/PcfControls/PcfControl.cs
+++ b/src/PAModel/Schemas/PcfControls/PcfControl.cs
@@ -33,7 +33,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Schemas.PcfControl
         public Dictionary<string, object> ExtensionData { get; set; }
 
 
-        private static IEnumerable<IDictionary<string, AuthConfigProperty>> GetAutConfigProperties(string authConfigPropertiesJson)
+        private static IEnumerable<IDictionary<string, AuthConfigProperty>> GetAuthConfigProperties(string authConfigPropertiesJson)
         {
             var authConfigPropertiesGroup = new List<IDictionary<string, AuthConfigProperty>>();
             using (var doc = JsonDocument.Parse(authConfigPropertiesJson))
@@ -62,7 +62,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Schemas.PcfControl
             pcfControl.ControlConstructor = dynamicControlDefinition.ControlConstructor;
             pcfControl.Resources = dynamicControlDefinition.Resources != null ? Utilities.JsonParse<Resource[]>(dynamicControlDefinition.Resources) : null;
             pcfControl.Properties = dynamicControlDefinition.Properties != null ? Utilities.JsonParse<IEnumerable<Property>>(dynamicControlDefinition.Properties) : null;
-            pcfControl.AuthConfigProperties = dynamicControlDefinition.AuthConfigProperties != null ? GetAutConfigProperties(dynamicControlDefinition.AuthConfigProperties) : null;
+            pcfControl.AuthConfigProperties = dynamicControlDefinition.AuthConfigProperties != null ? GetAuthConfigProperties(dynamicControlDefinition.AuthConfigProperties) : null;
             pcfControl.DataConnectors = dynamicControlDefinition.DataConnectors != null ? Utilities.JsonParse<IEnumerable<DataConnectorMetadata>>(dynamicControlDefinition.DataConnectors) : null;
             pcfControl.SubscribedFunctionalities = dynamicControlDefinition.SubscribedFunctionalities != null ? Utilities.JsonParse<Dictionary<string, string>>(dynamicControlDefinition.SubscribedFunctionalities) : null;
             pcfControl.IncludedProperties = dynamicControlDefinition.IncludedProperties != null ? Utilities.JsonParse<IEnumerable<Property>>(dynamicControlDefinition.IncludedProperties) : null;


### PR DESCRIPTION
If this is related to an issue open in GitHub, please link it to this ticket and put the URL here.

## Problem

Azure Pipeline uses out of support SDK

## Solution

Update to dot net SDK 6.0
