### PR TITLE
Fixed multiline msapp pack errors

### DIFF
--- a/src/PAModel/PAConvert/Yaml/YamlLexer.cs
+++ b/src/PAModel/PAConvert/Yaml/YamlLexer.cs
@@ -119,7 +119,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Yaml
     /// </summary>
     internal class YamlLexer
     {
-        private static string NewLine = "\r\n";
+        private static string NewLine = "\n";
 
         // The actual contents to read. 
         private readonly TextReader _reader;

--- a/src/PAModelTests/PAModelTests.csproj
+++ b/src/PAModelTests/PAModelTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
@@ -10,13 +10,13 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
     <PackageReference Include="YamlDotNet" Version="11.2.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/PAModelTests/YamlTest.cs
+++ b/src/PAModelTests/YamlTest.cs
@@ -516,7 +516,7 @@ P2: = ""hello"" & ""world""
         static void AssertLex(string expected, YamlLexer y)
         {
             var p = y.ReadNext();
-            Assert.AreEqual(expected, p.ToString());
+            Assert.AreEqual(NormNewlines(expected), p.ToString());
         }
 
         static void AssertLex(string expected, YamlLexer y, string sourceSpan)


### PR DESCRIPTION
If this is related to an issue open in GitHub, please link it to this ticket and put the URL here.

## Problem

What is the issue we are attempting to solve?
```
Error: Error   PA3013: Property Value Changed: TopParent.Children[0].Children[1].Rules[2].InvariantScript
Error   PA3011: Roundtrip validation on unpack failed.
You have found a bug; this is not a specific bug, rather an indicator that some bug has been encountered.
Please open an issue and log the entirety of this error log at https://github.com/microsoft/PowerApps-Language-Tooling
```

## Solution

What are we doing to solve this issue?
While validating we use normalized line endings but YamlLexer has Windows style endings hardcoded

## Validation

- How did you verify that this issue is truly fixed?
Updated unit tests to validate