### PR TITLE
Change Read to Read Exactly

### DIFF
--- a/src/PAModel/Utility/Utilities.cs
+++ b/src/PAModel/Utility/Utilities.cs
@@ -146,9 +146,8 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
                 do
                 {
-                    bytesRead += s.Read(buffer, bytesRead, (int)e.Length - bytesRead);
+                    bytesRead += s.ReadExactly(buffer);
                 } while (bytesRead < e.Length);
-
 
                 return buffer;
             }
@@ -178,7 +177,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="relativeTo"/> or <paramref name="path"/> is <c>null</c> or an empty string.</exception>
         /// <remarks>
         /// Want to use Path.GetRelativePath() from Net 2.1. But since we target netstandard 2.0, we need to shim it.
-        /// Convert to URIs and make the relative path. 
+        /// Convert to URIs and make the relative path.
         /// see https://stackoverflow.com/questions/275689/how-to-get-relative-path-from-absolute-path
         /// For reference, see Core's impl at: https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs#L861
         /// </remarks>


### PR DESCRIPTION
## Problem
Per a .NET upgrade to 6.0, 'Read' is no longer required to read the entire buffer before finishing. There is no guarantee on what it reads, or how much it reads.

## Solution

In order to fix this, we must use the new function ReadExactly.

## Validation

- Self-validation
- https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/partial-byte-reads-in-streams#recommended-action
