### PR TITLE
Fix Missing Logo File Throwing an Error

### DIFF
--- a/src/PAModel/Serializers/SourceSerializer.cs
+++ b/src/PAModel/Serializers/SourceSerializer.cs
@@ -368,10 +368,6 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
                     app._unknownFiles.Remove(key);
                     app._logoFile = logoFile;
                 }
-                else
-                {
-                    throw new InvalidOperationException($"Missing logo file {key}");
-                }
             }
         }
 

--- a/src/PAModel/Serializers/TransformLogo.cs
+++ b/src/PAModel/Serializers/TransformLogo.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             FileEntry logoFile = null;
             var publishInfo = app._publishInfo.JsonClone();
 
-            if (!string.IsNullOrEmpty(publishInfo?.LogoFileName))
+            if (!string.IsNullOrEmpty(publishInfo?.LogoFileName) && app._logoFile?.Name != null)
             {
                 app._assetFiles.Remove(app._logoFile.Name);
                 publishInfo.LogoFileName = app._entropy.OldLogoFileName ?? Path.GetFileName(app._logoFile.Name.ToPlatformPath());

--- a/src/PAModel/Serializers/TransformLogo.cs
+++ b/src/PAModel/Serializers/TransformLogo.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             FileEntry logoFile = null;
             var publishInfo = app._publishInfo.JsonClone();
 
-            if (!string.IsNullOrEmpty(publishInfo?.LogoFileName) && app._logoFile?.Name != null)
+            if (!string.IsNullOrEmpty(publishInfo?.LogoFileName) && app._logoFile != null)
             {
                 app._assetFiles.Remove(app._logoFile.Name);
                 publishInfo.LogoFileName = app._entropy.OldLogoFileName ?? Path.GetFileName(app._logoFile.Name.ToPlatformPath());

--- a/src/PAModel/Serializers/TransformLogo.cs
+++ b/src/PAModel/Serializers/TransformLogo.cs
@@ -50,13 +50,15 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
             if (!string.IsNullOrEmpty(publishInfo?.LogoFileName) && app._logoFile?.Name != null)
             {
-                app._assetFiles.Remove(app._logoFile.Name);
-                publishInfo.LogoFileName = app._entropy.OldLogoFileName ?? Path.GetFileName(app._logoFile.Name.ToPlatformPath());
-                logoFile = new FileEntry
+                if (app._assetFiles.Remove(app._logoFile.Name))
                 {
-                    Name = FilePath.RootedAt("Resources", FilePath.FromMsAppPath(publishInfo.LogoFileName)),
-                    RawBytes = app._logoFile.RawBytes
-                };
+                    publishInfo.LogoFileName = app._entropy.OldLogoFileName ?? Path.GetFileName(app._logoFile.Name.ToPlatformPath());
+                    logoFile = new FileEntry
+                    {
+                        Name = FilePath.RootedAt("Resources", FilePath.FromMsAppPath(publishInfo.LogoFileName)),
+                        RawBytes = app._logoFile.RawBytes
+                    };
+                }
             }
 
             return (publishInfo, logoFile);

--- a/src/PAModel/Serializers/TransformLogo.cs
+++ b/src/PAModel/Serializers/TransformLogo.cs
@@ -50,15 +50,13 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
             if (!string.IsNullOrEmpty(publishInfo?.LogoFileName) && app._logoFile?.Name != null)
             {
-                if (app._assetFiles.Remove(app._logoFile.Name))
+                app._assetFiles.Remove(app._logoFile.Name);
+                publishInfo.LogoFileName = app._entropy.OldLogoFileName ?? Path.GetFileName(app._logoFile.Name.ToPlatformPath());
+                logoFile = new FileEntry
                 {
-                    publishInfo.LogoFileName = app._entropy.OldLogoFileName ?? Path.GetFileName(app._logoFile.Name.ToPlatformPath());
-                    logoFile = new FileEntry
-                    {
-                        Name = FilePath.RootedAt("Resources", FilePath.FromMsAppPath(publishInfo.LogoFileName)),
-                        RawBytes = app._logoFile.RawBytes
-                    };
-                }
+                    Name = FilePath.RootedAt("Resources", FilePath.FromMsAppPath(publishInfo.LogoFileName)),
+                    RawBytes = app._logoFile.RawBytes
+                };
             }
 
             return (publishInfo, logoFile);

--- a/src/PAModel/Serializers/TransformLogo.cs
+++ b/src/PAModel/Serializers/TransformLogo.cs
@@ -48,15 +48,23 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             FileEntry logoFile = null;
             var publishInfo = app._publishInfo.JsonClone();
 
-            if (!string.IsNullOrEmpty(publishInfo?.LogoFileName) && app._logoFile != null)
-            {
-                app._assetFiles.Remove(app._logoFile.Name);
-                publishInfo.LogoFileName = app._entropy.OldLogoFileName ?? Path.GetFileName(app._logoFile.Name.ToPlatformPath());
-                logoFile = new FileEntry
+            if (app._logoFile != null) {
+                if (!string.IsNullOrEmpty(publishInfo?.LogoFileName))
                 {
-                    Name = FilePath.RootedAt("Resources", FilePath.FromMsAppPath(publishInfo.LogoFileName)),
-                    RawBytes = app._logoFile.RawBytes
-                };
+                    app._assetFiles.Remove(app._logoFile.Name);
+                    publishInfo.LogoFileName = app._entropy.OldLogoFileName ?? Path.GetFileName(app._logoFile.Name.ToPlatformPath());
+                    logoFile = new FileEntry
+                    {
+                        Name = FilePath.RootedAt("Resources", FilePath.FromMsAppPath(publishInfo.LogoFileName)),
+                        RawBytes = app._logoFile.RawBytes
+                    };
+                }
+            }
+            else {
+                if (app._entropy.OldLogoFileName != null)
+                {
+                    publishInfo.LogoFileName = app._entropy.OldLogoFileName;
+                }
             }
 
             return (publishInfo, logoFile);


### PR DESCRIPTION
## Problem

We don't want a missing logo file to throw an error, we'd like it to roundtrip so as not to block the user from packing the app.

## Solution

Remove the error that throws, and make sure the FileName is not null.

## Validation

- Self validation
