### PR TITLE
Net Core 3.1 is no longer supported. Converted to Net 6.0 LTS

### DIFF
--- a/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
+++ b/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
@@ -19,7 +19,7 @@
     <PackageReleaseNotes>
         Notice:
             This package is a preview release - use at your own risk.
-            This package is a .NET Standard 2.0 project, intended to work with .NET Framework 4.7.2 or later, and .NET Core 2.2 or later
+            This package is a .NET Standard 2.0 project, intended to work with .NET Framework 4.7.2 or later, and .NET 6.0 or later
             We have not stabilized on Namespace or Class names with this package as of yet and things will change as we move though the preview.
 
         See https://github.com/microsoft/PowerApps-Language-Tooling/releases for the latest release notes.

--- a/src/PASopa/PASopa.csproj
+++ b/src/PASopa/PASopa.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <PublicSign>true</PublicSign>


### PR DESCRIPTION
If this is related to an issue open in GitHub, please link it to this ticket and put the URL here.

## Problem

Net Core 3.1 is no longer supported

## Solution

Converted to Net 6.0 LTS
