### PR TITLE
Add reason to exceptions

### DIFF
--- a/src/Persistence/MsappPacking/MsappPackException.cs
+++ b/src/Persistence/MsappPacking/MsappPackException.cs
@@ -8,13 +8,20 @@ namespace Microsoft.PowerPlatform.PowerApps.Persistence.MsappPacking;
 /// </summary>
 public sealed class MsappPackException : Exception
 {
-    public MsappPackException(string message)
+    public MsappPackException(MsappPackExceptionReason reason, string message)
         : base(message)
     {
+        Reason = reason;
     }
 
-    public MsappPackException(string message, Exception innerException)
+    public MsappPackException(MsappPackExceptionReason reason, string message, Exception innerException)
         : base(message, innerException)
     {
+        Reason = reason;
     }
+
+    /// <summary>
+    /// Identifies the reason why this exception was thrown.
+    /// </summary>
+    public MsappPackExceptionReason Reason { get; }
 }

--- a/src/Persistence/MsappPacking/MsappPackExceptionReason.cs
+++ b/src/Persistence/MsappPacking/MsappPackExceptionReason.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.MsappPacking;
+
+/// <summary>
+/// Identifies the scenario in which an <see cref="MsappPackException"/> was thrown.
+/// </summary>
+public enum MsappPackExceptionReason
+{
+    /// <summary>
+    /// An output file already exists and overwriting output is not enabled.
+    /// </summary>
+    OutputAlreadyExists,
+}

--- a/src/Persistence/MsappPacking/MsappPackingService.cs
+++ b/src/Persistence/MsappPacking/MsappPackingService.cs
@@ -64,14 +64,14 @@ public sealed class MsappPackingService(
         if (!options.OverwriteOutput)
         {
             if (File.Exists(msaprPath))
-                throw new MsappUnpackException($"Output file '{msaprPath}' already exists and overwriting output is not enabled.");
+                throw new MsappUnpackException(MsappUnpackExceptionReason.OutputAlreadyExists, $"Output file '{msaprPath}' already exists and overwriting output is not enabled.");
 
             // Source code should all go into the same 'Src' folder, so we only need to see if it exists and has files inside
             // We will silently remove any empty 'Src' folder
             if (Directory.Exists(srcOutputDirectoryPath)
                 && Directory.EnumerateFiles(srcOutputDirectoryPath, "*", SearchOption.AllDirectories).Any())
             {
-                throw new MsappUnpackException($"Output folder '{srcOutputDirectoryPath}' is not empty and overwriting output is not enabled.");
+                throw new MsappUnpackException(MsappUnpackExceptionReason.OutputAlreadyExists, $"Output folder '{srcOutputDirectoryPath}' is not empty and overwriting output is not enabled.");
             }
 
             // Assets should all go into the same 'Assets' folder, so we only need to see if it exists and has files inside
@@ -79,7 +79,7 @@ public sealed class MsappPackingService(
             if (Directory.Exists(assetsOutputDirectoryPath)
                 && Directory.EnumerateFiles(assetsOutputDirectoryPath, "*", SearchOption.AllDirectories).Any())
             {
-                throw new MsappUnpackException($"Output folder '{assetsOutputDirectoryPath}' is not empty and overwriting output is not enabled.");
+                throw new MsappUnpackException(MsappUnpackExceptionReason.OutputAlreadyExists, $"Output folder '{assetsOutputDirectoryPath}' is not empty and overwriting output is not enabled.");
             }
         }
 
@@ -132,10 +132,10 @@ public sealed class MsappPackingService(
     internal static void ValidateMsappUnpackIsSupported(MsappArchive msappArchive)
     {
         if (msappArchive.MSAppStructureVersion < MinSupportedMSAppStructureVersion)
-            throw new MsappUnpackException($"MSAppStructureVersion {msappArchive.MSAppStructureVersion} is below the minimum supported version {MinSupportedMSAppStructureVersion}.");
+            throw new MsappUnpackException(MsappUnpackExceptionReason.UnsupportedMSAppStructureVersion, $"MSAppStructureVersion {msappArchive.MSAppStructureVersion} is below the minimum supported version {MinSupportedMSAppStructureVersion}.");
 
         if (msappArchive.DocVersion < MinSupportedDocVersion)
-            throw new MsappUnpackException($"DocVersion {msappArchive.DocVersion} is below the minimum supported version {MinSupportedDocVersion}.");
+            throw new MsappUnpackException(MsappUnpackExceptionReason.UnsupportedDocVersion, $"DocVersion {msappArchive.DocVersion} is below the minimum supported version {MinSupportedDocVersion}.");
     }
 
     private static MsaprHeaderJson CreateMsaprHeaderJson(UnpackedConfiguration unpackedConfig)
@@ -235,7 +235,7 @@ public sealed class MsappPackingService(
         msaprPath = Path.GetFullPath(msaprPath);
 
         if (!options.OverwriteOutput && File.Exists(outputMsappPath))
-            throw new MsappPackException($"Output file '{outputMsappPath}' already exists and overwriting output is not enabled.");
+            throw new MsappPackException(MsappPackExceptionReason.OutputAlreadyExists, $"Output file '{outputMsappPath}' already exists and overwriting output is not enabled.");
 
         var unpackedFolderPath = Path.GetDirectoryName(msaprPath)!;
 

--- a/src/Persistence/MsappPacking/MsappUnpackException.cs
+++ b/src/Persistence/MsappPacking/MsappUnpackException.cs
@@ -8,13 +8,20 @@ namespace Microsoft.PowerPlatform.PowerApps.Persistence.MsappPacking;
 /// </summary>
 public sealed class MsappUnpackException : Exception
 {
-    public MsappUnpackException(string message)
+    public MsappUnpackException(MsappUnpackExceptionReason reason, string message)
         : base(message)
     {
+        Reason = reason;
     }
 
-    public MsappUnpackException(string message, Exception innerException)
+    public MsappUnpackException(MsappUnpackExceptionReason reason, string message, Exception innerException)
         : base(message, innerException)
     {
+        Reason = reason;
     }
+
+    /// <summary>
+    /// Identifies the reason why this exception was thrown.
+    /// </summary>
+    public MsappUnpackExceptionReason Reason { get; }
 }

--- a/src/Persistence/MsappPacking/MsappUnpackExceptionReason.cs
+++ b/src/Persistence/MsappPacking/MsappUnpackExceptionReason.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.MsappPacking;
+
+/// <summary>
+/// Identifies the scenario in which an <see cref="MsappUnpackException"/> was thrown.
+/// </summary>
+public enum MsappUnpackExceptionReason
+{
+    /// <summary>
+    /// An output file or folder already exists and overwriting output is not enabled.
+    /// </summary>
+    OutputAlreadyExists,
+
+    /// <summary>
+    /// The MSApp structure version is below the minimum supported version.
+    /// </summary>
+    UnsupportedMSAppStructureVersion,
+
+    /// <summary>
+    /// The document version is below the minimum supported version.
+    /// </summary>
+    UnsupportedDocVersion,
+}


### PR DESCRIPTION
To allow clients the ability to programatically handle certain error conditions this change adds a 'Reason' enum and property to exceptions.