### PR TITLE
Upgrade YamlDotNet to 16.1.3

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -31,7 +31,7 @@
     <PackageVersion Include="System.Text.Encodings.Web" Version="8.0.0" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageVersion Include="Yaml2JsonNode" Version="2.1.1" />
-    <PackageVersion Include="YamlDotNet" Version="15.1.6" />
+    <PackageVersion Include="YamlDotNet" Version="16.1.3" />
 
   </ItemGroup>
 </Project>

--- a/src/PAModel/packages.lock.json
+++ b/src/PAModel/packages.lock.json
@@ -42,9 +42,9 @@
       },
       "YamlDotNet": {
         "type": "Direct",
-        "requested": "[15.1.6, )",
-        "resolved": "15.1.6",
-        "contentHash": "T/cQEK/KHK96Q8kytJ4iUGDXg1/fj2Qtk6rCQeIlHYU1zTeyGVHW0QNZgREQyxZpygGMDMmrXNWt0sj5TsQnjA=="
+        "requested": "[16.1.3, )",
+        "resolved": "16.1.3",
+        "contentHash": "gtHGiDvU9VTtWte8f0thIM38cL1oowOjStKpeAEKKfA+Rc4AvekJzqFDZiiPcc4kw00ZiwR4OTJS56L16q98DQ=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -116,9 +116,9 @@
       },
       "YamlDotNet": {
         "type": "Direct",
-        "requested": "[15.1.6, )",
-        "resolved": "15.1.6",
-        "contentHash": "T/cQEK/KHK96Q8kytJ4iUGDXg1/fj2Qtk6rCQeIlHYU1zTeyGVHW0QNZgREQyxZpygGMDMmrXNWt0sj5TsQnjA=="
+        "requested": "[16.1.3, )",
+        "resolved": "16.1.3",
+        "contentHash": "gtHGiDvU9VTtWte8f0thIM38cL1oowOjStKpeAEKKfA+Rc4AvekJzqFDZiiPcc4kw00ZiwR4OTJS56L16q98DQ=="
       }
     },
     "net8.0": {
@@ -142,9 +142,9 @@
       },
       "YamlDotNet": {
         "type": "Direct",
-        "requested": "[15.1.6, )",
-        "resolved": "15.1.6",
-        "contentHash": "T/cQEK/KHK96Q8kytJ4iUGDXg1/fj2Qtk6rCQeIlHYU1zTeyGVHW0QNZgREQyxZpygGMDMmrXNWt0sj5TsQnjA=="
+        "requested": "[16.1.3, )",
+        "resolved": "16.1.3",
+        "contentHash": "gtHGiDvU9VTtWte8f0thIM38cL1oowOjStKpeAEKKfA+Rc4AvekJzqFDZiiPcc4kw00ZiwR4OTJS56L16q98DQ=="
       }
     }
   }

--- a/src/Persistence.Tests/PaYaml/Serialization/NamedObjectMappingSerializationTests.cs
+++ b/src/Persistence.Tests/PaYaml/Serialization/NamedObjectMappingSerializationTests.cs
@@ -2,12 +2,26 @@
 // Licensed under the MIT License.
 
 using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models;
+using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Serialization;
+using YamlDotNet.Serialization;
 
 namespace Persistence.Tests.PaYaml.Serialization;
 
 [TestClass]
 public class NamedObjectMappingSerializationTests : SerializationTestBase
 {
+    protected override void ConfigureYamlDotNetDeserializer(DeserializerBuilder builder, PaYamlSerializationContext context)
+    {
+        base.ConfigureYamlDotNetDeserializer(builder, context);
+        builder.WithTypeConverter(new NamedObjectMappingYamlConverter());
+    }
+
+    protected override void ConfigureYamlDotNetSerializer(SerializerBuilder builder, PaYamlSerializationContext context)
+    {
+        base.ConfigureYamlDotNetSerializer(builder, context);
+        builder.WithTypeConverter(new NamedObjectMappingYamlConverter());
+    }
+
     [TestMethod]
     // Null literals
     [DataRow("TheMapping: ~", null)]

--- a/src/Persistence.Tests/PaYaml/Serialization/NamedObjectSequenceSerializationTests.cs
+++ b/src/Persistence.Tests/PaYaml/Serialization/NamedObjectSequenceSerializationTests.cs
@@ -13,13 +13,13 @@ public class NamedObjectSequenceSerializationTests : SerializationTestBase
     protected override void ConfigureYamlDotNetDeserializer(DeserializerBuilder builder, PaYamlSerializationContext context)
     {
         base.ConfigureYamlDotNetDeserializer(builder, context);
-        builder.WithTypeConverter(new NamedObjectYamlConverter<string>(context));
+        builder.WithTypeConverter(new NamedObjectYamlConverter<string>());
     }
 
     protected override void ConfigureYamlDotNetSerializer(SerializerBuilder builder, PaYamlSerializationContext context)
     {
         base.ConfigureYamlDotNetSerializer(builder, context);
-        builder.WithTypeConverter(new NamedObjectYamlConverter<string>(context));
+        builder.WithTypeConverter(new NamedObjectYamlConverter<string>());
     }
 
     [TestMethod]
@@ -75,7 +75,7 @@ public class NamedObjectSequenceSerializationTests : SerializationTestBase
         var testObject = DeserializeViaYamlDotNet<TestOM<string>>(yaml);
         testObject.ShouldNotBeNull();
         testObject.TheSequence.ShouldNotBeNull();
-        testObject.TheSequence.Names.Should().Equal(new[] { "n1", "n3", "n2" }, "ordering of a sequence is by code order");
+        testObject.TheSequence.Names.Should().Equal(["n1", "n3", "n2"], "ordering of a sequence is by code order");
         testObject.TheSequence.GetNamedObject("n1").Should()
             .HaveValueEqual("v1")
             .And.HaveStartEqual(2, 5);
@@ -92,7 +92,7 @@ public class NamedObjectSequenceSerializationTests : SerializationTestBase
     {
         SerializeViaYamlDotNet(new TestOM<string> { TheSequence = null })
             .Should().Be("{}" + DefaultOptions.NewLine);
-        SerializeViaYamlDotNet(new TestOM<string> { TheSequence = new() })
+        SerializeViaYamlDotNet(new TestOM<string> { TheSequence = [] })
             .Should().Be("{}" + DefaultOptions.NewLine);
     }
 

--- a/src/Persistence.Tests/PaYaml/Serialization/SerializationTestBase.cs
+++ b/src/Persistence.Tests/PaYaml/Serialization/SerializationTestBase.cs
@@ -21,7 +21,6 @@ public abstract class SerializationTestBase : VSTestBase
         using var serializationContext = new PaYamlSerializationContext(options);
         var builder = new SerializerBuilder();
         ConfigureYamlDotNetSerializer(builder, serializationContext);
-        serializationContext.ValueSerializer = builder.BuildValueSerializer();
         var serializer = builder.Build();
 
         return serializer.Serialize(testObject);
@@ -40,11 +39,9 @@ public abstract class SerializationTestBase : VSTestBase
         using var serializationContext = new PaYamlSerializationContext(options);
         var builder = new DeserializerBuilder();
         ConfigureYamlDotNetDeserializer(builder, serializationContext);
-        serializationContext.ValueDeserializer = builder.BuildValueDeserializer();
         var deserializer = builder.Build();
 
         var value = deserializer.Deserialize<T?>(yaml);
-        serializationContext.OnDeserialization();
         return value;
     }
 

--- a/src/Persistence/PaYaml/Models/NamedObjectMapping.cs
+++ b/src/Persistence/PaYaml/Models/NamedObjectMapping.cs
@@ -1,10 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Serialization;
-using YamlDotNet.Core;
-using YamlDotNet.Serialization;
-
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models;
 
 /// <summary>
@@ -41,15 +37,5 @@ public class NamedObjectMapping<TValue> : NamedObjectMappingBase<string, TValue,
         _ = value ?? throw new ArgumentNullException(nameof(value));
 
         return new NamedObject<TValue>(name, value);
-    }
-
-    protected override NamedObject<TValue> ReadNamedObjectFromMappingEntryEvents(IParser parser, ObjectDeserializer nestedObjectDeserializer)
-    {
-        return NamedObjectYamlConverter<TValue>.ReadNameAndValueEventsCore(parser, nestedObjectDeserializer);
-    }
-
-    protected override void WriteNamedObjectToMappingEntryEvents(IEmitter emitter, NamedObject<TValue> namedObject, ObjectSerializer nestedObjectSerializer)
-    {
-        NamedObjectYamlConverter<TValue>.WriteNameAndValueEventsCore(emitter, namedObject, nestedObjectSerializer);
     }
 }

--- a/src/Persistence/PaYaml/Models/NamedObjectMappingBase.cs
+++ b/src/Persistence/PaYaml/Models/NamedObjectMappingBase.cs
@@ -3,17 +3,13 @@
 
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Serialization;
-using YamlDotNet.Core;
-using YamlDotNet.Core.Events;
-using YamlDotNet.Serialization;
 
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models;
 
 /// <summary>
 /// Base implementation for an <see cref="INamedObject{TName, TValue}"/> yaml mapping.
 /// </summary>
-public abstract class NamedObjectMappingBase<TName, TValue, TNamedObject> : INamedObjectCollection<TName, TValue, TNamedObject>, IYamlConvertible
+public abstract class NamedObjectMappingBase<TName, TValue, TNamedObject> : INamedObjectCollection<TName, TValue, TNamedObject>
     where TName : notnull
     where TValue : notnull
     where TNamedObject : INamedObject<TName, TValue>
@@ -157,59 +153,4 @@ public abstract class NamedObjectMappingBase<TName, TValue, TNamedObject> : INam
             return false;
         }
     }
-
-    #region IYamlConvertible
-
-    private void Read(IParser parser, Type expectedType, ObjectDeserializer nestedObjectDeserializer)
-    {
-        Debug.Assert(expectedType.IsAssignableTo(typeof(NamedObjectMappingBase<TName, TValue, TNamedObject>)));
-
-        if (parser.TryConsumeNull())
-        {
-            // REVIEW: We may not want to support null scalars when reading named object mappings.
-            //         This will require us to use a custom converter to be able to have access to return a null value.
-            // For now, we think all uses would be benign currently to just treat null inputs as an empty collection:
-            return;
-        }
-
-        parser.Consume<MappingStart>();
-        while (!parser.TryConsume<MappingEnd>(out _))
-        {
-            var itemStartEvent = parser.Current!;
-            var namedObject = ReadNamedObjectFromMappingEntryEvents(parser, nestedObjectDeserializer);
-
-            if (!TryAdd(namedObject))
-            {
-                var existingNamedObject = GetNamedObject(namedObject.Name);
-                throw new YamlException(itemStartEvent.Start, itemStartEvent.End, $"Duplicate name '{namedObject.Name}' used at {itemStartEvent}. First use is located at {existingNamedObject.Start}.");
-            }
-        }
-    }
-
-    private void Write(IEmitter emitter, ObjectSerializer nestedObjectSerializer)
-    {
-        emitter.Emit(new MappingStart(AnchorName.Empty, TagName.Empty, isImplicit: true, MappingStyle.Block));
-        foreach (var namedObject in InnerCollection.Values)
-        {
-            WriteNamedObjectToMappingEntryEvents(emitter, namedObject, nestedObjectSerializer);
-        }
-
-        emitter.Emit(new MappingEnd());
-    }
-
-    protected abstract TNamedObject ReadNamedObjectFromMappingEntryEvents(IParser parser, ObjectDeserializer nestedObjectDeserializer);
-
-    protected abstract void WriteNamedObjectToMappingEntryEvents(IEmitter emitter, TNamedObject namedObject, ObjectSerializer nestedObjectSerializer);
-
-    void IYamlConvertible.Read(IParser parser, Type expectedType, ObjectDeserializer nestedObjectDeserializer)
-    {
-        Read(parser, expectedType, nestedObjectDeserializer);
-    }
-
-    void IYamlConvertible.Write(IEmitter emitter, ObjectSerializer nestedObjectSerializer)
-    {
-        Write(emitter, nestedObjectSerializer);
-    }
-
-    #endregion
 }

--- a/src/Persistence/PaYaml/Models/PaYamlLocation.cs
+++ b/src/Persistence/PaYaml/Models/PaYamlLocation.cs
@@ -5,7 +5,7 @@ using YamlDotNet.Core;
 
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models;
 
-public record PaYamlLocation(int Line, int Column)
+public record PaYamlLocation(long Line, long Column)
 {
     internal static PaYamlLocation? FromMark(Mark mark)
     {

--- a/src/Persistence/PaYaml/Serialization/NamedObjectMappingYamlConverter.cs
+++ b/src/Persistence/PaYaml/Serialization/NamedObjectMappingYamlConverter.cs
@@ -9,16 +9,16 @@ using YamlDotNet.Serialization;
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Serialization;
 
 /// <summary>
-/// Converts any <see cref="NamedObject{TValue}"/> to and from YAML.
+/// Converts any <see cref="NamedObjectMapping{TValue}"/> to and from YAML.
 /// The converter is non-generic so a single registration handles all closed <c>TValue</c> types.
 /// </summary>
-internal sealed class NamedObjectYamlConverter : IYamlTypeConverter
+internal sealed class NamedObjectMappingYamlConverter : IYamlTypeConverter
 {
     private static readonly ConcurrentDictionary<Type, IYamlTypeConverter> ConverterCache = new();
 
     public bool Accepts(Type type)
     {
-        return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(NamedObject<>);
+        return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(NamedObjectMapping<>);
     }
 
     public object? ReadYaml(IParser parser, Type type, ObjectDeserializer rootDeserializer)
@@ -31,12 +31,12 @@ internal sealed class NamedObjectYamlConverter : IYamlTypeConverter
         GetConverter(type).WriteYaml(emitter, value, type, serializer);
     }
 
-    private static IYamlTypeConverter GetConverter(Type closedNamedObjectType)
+    private static IYamlTypeConverter GetConverter(Type closedMappingType)
     {
-        return ConverterCache.GetOrAdd(closedNamedObjectType, static t =>
+        return ConverterCache.GetOrAdd(closedMappingType, static t =>
         {
             var valueType = t.GetGenericArguments()[0];
-            var converterType = typeof(NamedObjectYamlConverter<>).MakeGenericType(valueType);
+            var converterType = typeof(NamedObjectMappingYamlConverter<>).MakeGenericType(valueType);
             return (IYamlTypeConverter)Activator.CreateInstance(converterType)!;
         });
     }

--- a/src/Persistence/PaYaml/Serialization/NamedObjectMappingYamlConverterOfT.cs
+++ b/src/Persistence/PaYaml/Serialization/NamedObjectMappingYamlConverterOfT.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Serialization;
+
+/// <summary>
+/// Strongly-typed converter for <see cref="NamedObjectMapping{TValue}"/>.
+/// Typically discovered and dispatched to by the non-generic
+/// <see cref="NamedObjectMappingYamlConverter"/>, but can also be registered directly.
+/// </summary>
+internal sealed class NamedObjectMappingYamlConverter<TValue> : YamlConverter<NamedObjectMapping<TValue>>
+    where TValue : notnull
+{
+    public override NamedObjectMapping<TValue> ReadYaml(IParser parser, Type typeToConvert, ObjectDeserializer rootDeserializer)
+    {
+        var mapping = new NamedObjectMapping<TValue>();
+
+        if (parser.TryConsumeNull())
+        {
+            // REVIEW: We may not want to support null scalars when reading named object mappings.
+            // For now, treat null inputs as an empty collection (matches prior IYamlConvertible behavior).
+            return mapping;
+        }
+
+        parser.Consume<MappingStart>();
+        while (!parser.TryConsume<MappingEnd>(out _))
+        {
+            var itemStartEvent = parser.Current!;
+            var namedObject = NamedObjectYamlConverter<TValue>.ReadNameAndValueEventsCore(parser, rootDeserializer);
+
+            if (!mapping.TryAdd(namedObject))
+            {
+                var existingNamedObject = mapping.GetNamedObject(namedObject.Name);
+                throw new YamlException(itemStartEvent.Start, itemStartEvent.End, $"Duplicate name '{namedObject.Name}' used at {itemStartEvent}. First use is located at {existingNamedObject.Start}.");
+            }
+        }
+
+        return mapping;
+    }
+
+    public override void WriteYaml(IEmitter emitter, NamedObjectMapping<TValue>? value, Type typeToConvert, ObjectSerializer serializer)
+    {
+        if (value is null)
+        {
+            emitter.EmitNull();
+            return;
+        }
+
+        emitter.Emit(new MappingStart(AnchorName.Empty, TagName.Empty, isImplicit: true, MappingStyle.Block));
+        foreach (var namedObject in value)
+        {
+            NamedObjectYamlConverter<TValue>.WriteNameAndValueEventsCore(emitter, namedObject, serializer);
+        }
+
+        emitter.Emit(new MappingEnd());
+    }
+}

--- a/src/Persistence/PaYaml/Serialization/NamedObjectYamlConverterOfT.cs
+++ b/src/Persistence/PaYaml/Serialization/NamedObjectYamlConverterOfT.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models;
+using YamlDotNet.Serialization;
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Serialization;
+
+internal class NamedObjectYamlConverter<TValue> : YamlConverter<NamedObject<TValue>>
+    where TValue : notnull
+{
+    internal static NamedObject<TValue> ReadNameAndValueEventsCore(IParser parser, ObjectDeserializer rootDeserializer)
+    {
+        _ = parser.Current ?? throw new InvalidOperationException("The parser has not been started or has nothing to read.");
+        _ = rootDeserializer ?? throw new ArgumentNullException(nameof(rootDeserializer));
+
+        // The default representation is expected to represent a single-item mapping
+        var start = parser.Current.Start;
+        var name = (string?)rootDeserializer(typeof(string)) ?? throw new YamlException(start, parser.Current.End, $"Named object key cannot be null.");
+        var value = (TValue?)rootDeserializer(typeof(TValue)) ?? throw new YamlException(start, parser.Current.End, $"Named object value cannot be null.");
+
+        return new NamedObject<TValue>(name, value) { Start = PaYamlLocation.FromMark(start) };
+    }
+
+    internal static void WriteNameAndValueEventsCore(IEmitter emitter, NamedObject<TValue> namedObject, ObjectSerializer serializer)
+    {
+        _ = emitter ?? throw new ArgumentNullException(nameof(emitter));
+        _ = namedObject ?? throw new ArgumentNullException(nameof(namedObject));
+        _ = serializer ?? throw new ArgumentNullException(nameof(serializer));
+
+        // Only write the events for the mapping key/value.
+        serializer(namedObject.Name, typeof(string));
+        serializer(namedObject.Value, typeof(TValue));
+    }
+
+    public override NamedObject<TValue> ReadYaml(IParser parser, Type typeToConvert, ObjectDeserializer rootDeserializer)
+    {
+        // The default representation is expected to represent a single-item mapping
+        var mappingStart = parser.Consume<MappingStart>();
+        var namedObject = ReadNameAndValueEventsCore(parser, rootDeserializer);
+
+        // There shouldn't be any more keys in the mapping
+        parser.Consume<MappingEnd>();
+
+        return namedObject;
+    }
+
+    public override void WriteYaml(IEmitter emitter, NamedObject<TValue>? value, Type typeToConvert, ObjectSerializer serializer)
+    {
+        if (value is null)
+        {
+            emitter.EmitNull();
+            return;
+        }
+
+        // The default representation is expected to represent a single-item mapping
+        emitter.Emit(new MappingStart(AnchorName.Empty, TagName.Empty, isImplicit: true, MappingStyle.Block));
+
+        WriteNameAndValueEventsCore(emitter, value, serializer);
+
+        emitter.Emit(new MappingEnd());
+    }
+}

--- a/src/Persistence/PaYaml/Serialization/PFxExpressionYamlConverter.cs
+++ b/src/Persistence/PaYaml/Serialization/PFxExpressionYamlConverter.cs
@@ -8,23 +8,18 @@ using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.PowerFx;
 
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Serialization;
 
-internal class PFxExpressionYamlConverter : IYamlTypeConverter
+internal class PFxExpressionYamlConverter(PFxExpressionYamlFormattingOptions formattingOptions) : IYamlTypeConverter
 {
     private static readonly char[] LineTerminators = ['\r', '\n', '\x85', '\x2028', '\x2029'];
 
-    private readonly PFxExpressionYamlFormattingOptions _formattingOptions;
-
-    public PFxExpressionYamlConverter(PFxExpressionYamlFormattingOptions formattingOptions)
-    {
-        _formattingOptions = formattingOptions ?? throw new ArgumentNullException(nameof(formattingOptions));
-    }
+    private readonly PFxExpressionYamlFormattingOptions _formattingOptions = formattingOptions;
 
     public bool Accepts(Type type)
     {
         return type == typeof(PFxExpressionYaml);
     }
 
-    public object? ReadYaml(IParser parser, Type type)
+    public object? ReadYaml(IParser parser, Type type, ObjectDeserializer _)
     {
         if (parser.TryConsumeNull())
             return null;
@@ -41,7 +36,7 @@ internal class PFxExpressionYamlConverter : IYamlTypeConverter
         throw new YamlException(scalar.Start, scalar.End, $"Power Fx expressions must start with '{PFxExpressionYamlFormattingOptions.ScalarPrefix}'.");
     }
 
-    public void WriteYaml(IEmitter emitter, object? value, Type type)
+    public void WriteYaml(IEmitter emitter, object? value, Type type, ObjectSerializer _)
     {
         var expression = (PFxExpressionYaml?)value;
         if (expression is null)

--- a/src/Persistence/PaYaml/Serialization/PaYamlSerializationContext.cs
+++ b/src/Persistence/PaYaml/Serialization/PaYamlSerializationContext.cs
@@ -1,46 +1,24 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV3;
-using YamlDotNet.Core;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
-using YamlDotNet.Serialization.Utilities;
 
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Serialization;
 
-public class PaYamlSerializationContext(PaYamlSerializerOptions options) : IDisposable
+public class PaYamlSerializationContext : IDisposable
 {
-    private readonly SerializerState _serializerState = new();
     private bool _isDisposed;
+
+    public PaYamlSerializationContext(PaYamlSerializerOptions options)
+    {
+        Options = options ?? throw new ArgumentNullException(nameof(options));
+    }
 
     /// <summary>
     /// The options used when creating this context.
     /// </summary>
-    public PaYamlSerializerOptions Options { get; } = options ?? throw new ArgumentNullException(nameof(options));
-
-    internal IValueSerializer? ValueSerializer { get; set; }
-
-    internal IValueDeserializer? ValueDeserializer { get; set; }
-
-    public ObjectDeserializer CreateObjectDeserializer(IParser parser)
-    {
-        var valueDeserializer = ValueDeserializer ?? throw new InvalidOperationException($"{nameof(ValueDeserializer)} is not set.");
-
-        return (t) => valueDeserializer.DeserializeValue(parser, t, _serializerState, valueDeserializer);
-    }
-
-    public ObjectSerializer CreateObjectSerializer(IEmitter emitter)
-    {
-        var valueSerializer = ValueSerializer ?? throw new InvalidOperationException($"{nameof(ValueSerializer)} is not set.");
-
-        return (v, t) => valueSerializer.SerializeValue(emitter, v, t);
-    }
-
-    internal void OnDeserialization()
-    {
-        _serializerState.OnDeserialization();
-    }
+    public PaYamlSerializerOptions Options { get; }
 
     internal void ApplyToDeserializerBuilder(DeserializerBuilder builder)
     {
@@ -48,6 +26,7 @@ public class PaYamlSerializationContext(PaYamlSerializerOptions options) : IDisp
             .WithDuplicateKeyChecking()
             .IgnoreFields()
             ;
+
         AddTypeConverters(builder);
         Options.AdditionalDeserializerConfiguration?.Invoke(builder);
     }
@@ -76,8 +55,8 @@ public class PaYamlSerializationContext(PaYamlSerializerOptions options) : IDisp
         where TBuilder : BuilderSkeleton<TBuilder>
     {
         builder.WithTypeConverter(new PFxExpressionYamlConverter(Options.PFxExpressionYamlFormatting));
-        builder.WithTypeConverter(new NamedObjectYamlConverter<ControlInstance>(this));
-        builder.WithTypeConverter(new NamedObjectYamlConverter<ComponentCustomPropertyParameter>(this));
+        builder.WithTypeConverter(new NamedObjectYamlConverter());
+        builder.WithTypeConverter(new NamedObjectMappingYamlConverter());
     }
 
     /// <summary>
@@ -93,11 +72,6 @@ public class PaYamlSerializationContext(PaYamlSerializerOptions options) : IDisp
     {
         if (!_isDisposed)
         {
-            if (disposing)
-            {
-                _serializerState.Dispose();
-            }
-
             _isDisposed = true;
         }
     }

--- a/src/Persistence/PaYaml/Serialization/PaYamlSerializer.cs
+++ b/src/Persistence/PaYaml/Serialization/PaYamlSerializer.cs
@@ -52,7 +52,6 @@ public static class PaYamlSerializer
         using var context = new PaYamlSerializationContext(options);
         var builder = new SerializerBuilder();
         context.ApplyToSerializerBuilder(builder);
-        context.ValueSerializer = builder.BuildValueSerializer();
         var serializer = builder.Build();
 
         try
@@ -104,15 +103,11 @@ public static class PaYamlSerializer
         using var context = new PaYamlSerializationContext(options);
         var builder = new DeserializerBuilder();
         context.ApplyToDeserializerBuilder(builder);
-        context.ValueDeserializer = builder.BuildValueDeserializer();
         var serializer = builder.Build();
 
         try
         {
             var value = serializer.Deserialize<TValue>(reader);
-
-            // Must call OnDeserialization to invoke any post-deserialization callbacks on the deserialized object tree.
-            context.OnDeserialization();
 
             return value;
         }

--- a/src/Persistence/PaYaml/Serialization/YamlConverterOfT.cs
+++ b/src/Persistence/PaYaml/Serialization/YamlConverterOfT.cs
@@ -9,14 +9,7 @@ namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Serialization;
 
 public abstract class YamlConverter<T> : IYamlTypeConverter
 {
-    protected YamlConverter(PaYamlSerializationContext context)
-    {
-        SerializationContext = context ?? throw new ArgumentNullException(nameof(context));
-    }
-
     public Type Type { get; } = typeof(T);
-
-    public PaYamlSerializationContext SerializationContext { get; }
 
     /// <summary>
     /// The default implementation returns true when <paramref name="type"/> equals typeof(<typeparamref name="T"/>).
@@ -26,19 +19,19 @@ public abstract class YamlConverter<T> : IYamlTypeConverter
         return type == Type;
     }
 
-    public abstract T ReadYaml(IParser parser, Type typeToConvert);
+    public abstract T ReadYaml(IParser parser, Type typeToConvert, ObjectDeserializer rootDeserializer);
 
-    public abstract void WriteYaml(IEmitter emitter, T? value, Type typeToConvert);
+    public abstract void WriteYaml(IEmitter emitter, T? value, Type typeToConvert, ObjectSerializer serializer);
 
-    object? IYamlTypeConverter.ReadYaml(IParser parser, Type typeToConvert)
+    object? IYamlTypeConverter.ReadYaml(IParser parser, Type typeToConvert, ObjectDeserializer rootDeserializer)
     {
-        return ReadYaml(parser, typeToConvert);
+        return ReadYaml(parser, typeToConvert, rootDeserializer);
     }
 
-    void IYamlTypeConverter.WriteYaml(IEmitter emitter, object? value, Type typeToConvert)
+    void IYamlTypeConverter.WriteYaml(IEmitter emitter, object? value, Type typeToConvert, ObjectSerializer serializer)
     {
         var valueOfT = YamlSerialization.UnboxOnWrite<T>(value);
-        WriteYaml(emitter, valueOfT, typeToConvert);
+        WriteYaml(emitter, valueOfT, typeToConvert, serializer);
     }
 }
 

--- a/src/Persistence/PaYaml/Serialization/YamlDotNetExtensions.cs
+++ b/src/Persistence/PaYaml/Serialization/YamlDotNetExtensions.cs
@@ -23,7 +23,7 @@ internal static class YamlDotNetExtensions
         // NullNodeDeserializer.Deserialize is undocumented, but here's a good summary of what it does:
         // Attempts to consume the current node event iif it represents a YAML null value. Otherwise, the current event stays.
         // Returns true if the current node was a null value and was consumed; otherwise, false.
-        return _nullNodeDeserializer.Deserialize(parser, _typeofObject, null!, out _);
+        return _nullNodeDeserializer.Deserialize(parser, _typeofObject, null!, out _, null!);
     }
 
     public static void EmitNull(this IEmitter emitter)

--- a/src/Persistence/PersistenceErrorCode.cs
+++ b/src/Persistence/PersistenceErrorCode.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Serialization;
 using System.ComponentModel;
 
 namespace Microsoft.PowerPlatform.PowerApps.Persistence;

--- a/src/Persistence/packages.lock.json
+++ b/src/Persistence/packages.lock.json
@@ -82,9 +82,9 @@
       },
       "YamlDotNet": {
         "type": "Direct",
-        "requested": "[15.1.6, )",
-        "resolved": "15.1.6",
-        "contentHash": "T/cQEK/KHK96Q8kytJ4iUGDXg1/fj2Qtk6rCQeIlHYU1zTeyGVHW0QNZgREQyxZpygGMDMmrXNWt0sj5TsQnjA=="
+        "requested": "[16.1.3, )",
+        "resolved": "16.1.3",
+        "contentHash": "gtHGiDvU9VTtWte8f0thIM38cL1oowOjStKpeAEKKfA+Rc4AvekJzqFDZiiPcc4kw00ZiwR4OTJS56L16q98DQ=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -144,9 +144,9 @@
       },
       "YamlDotNet": {
         "type": "Direct",
-        "requested": "[15.1.6, )",
-        "resolved": "15.1.6",
-        "contentHash": "T/cQEK/KHK96Q8kytJ4iUGDXg1/fj2Qtk6rCQeIlHYU1zTeyGVHW0QNZgREQyxZpygGMDMmrXNWt0sj5TsQnjA=="
+        "requested": "[16.1.3, )",
+        "resolved": "16.1.3",
+        "contentHash": "gtHGiDvU9VTtWte8f0thIM38cL1oowOjStKpeAEKKfA+Rc4AvekJzqFDZiiPcc4kw00ZiwR4OTJS56L16q98DQ=="
       }
     },
     "net8.0": {
@@ -167,9 +167,9 @@
       },
       "YamlDotNet": {
         "type": "Direct",
-        "requested": "[15.1.6, )",
-        "resolved": "15.1.6",
-        "contentHash": "T/cQEK/KHK96Q8kytJ4iUGDXg1/fj2Qtk6rCQeIlHYU1zTeyGVHW0QNZgREQyxZpygGMDMmrXNWt0sj5TsQnjA=="
+        "requested": "[16.1.3, )",
+        "resolved": "16.1.3",
+        "contentHash": "gtHGiDvU9VTtWte8f0thIM38cL1oowOjStKpeAEKKfA+Rc4AvekJzqFDZiiPcc4kw00ZiwR4OTJS56L16q98DQ=="
       }
     }
   }


### PR DESCRIPTION
The drive for this change is to match version used in Pac CLI. Since 16.0.0 had some breaking changes, we want to update to make sure we don't end up having runtime binary breaks.

- Remove workarounds related to being able to deserialize nested objects, as it's now passed into converter APIs
- Created `NamedObjectYamlConverter` to simplify generic type conversions
- Created `NamedObjectMappingYamlConverter` to handle (de)serialization of `NamedObjectMapping{TValue}`, replacing the previous implementation of `IYamlConvertible`
