### PR TITLE
Improve yaml parsing errors and msapp compare errors

### DIFF
--- a/src/PAModel/MsAppTest.cs
+++ b/src/PAModel/MsAppTest.cs
@@ -325,11 +325,12 @@ internal class MsAppTest
         Debug.Assert(jsonArray.ValueKind == JsonValueKind.Array);
 
         // For some arrays, it's better to use a named sub-property as the indexer when ordering of the items in the array is not significant.
-        var namedIndexPropertyName = path switch
+        var (namedIndexPropertyName, isOrderSignificant) = path switch
         {
-            _ when path.StartsWith("TopParent.") && path.EndsWith(".Rules") => "Property",
-            _ when path.StartsWith("TopParent.") && path.EndsWith(".DynamicProperties") => "PropertyName",
-            _ => null
+            _ when path.StartsWith("TopParent.") && path.EndsWith(".Rules") => ("Property", false),
+            _ when path.StartsWith("TopParent.") && path.EndsWith(".DynamicProperties") => ("PropertyName", false),
+            _ when path.StartsWith("TopParent.") && path.EndsWith(".Children") => ("Name", true),
+            _ => (null, true)
         };
 
         return jsonArray.EnumerateArray()
@@ -337,12 +338,26 @@ internal class MsAppTest
             {
                 var arraySubPath = $"{path}[{index}]";
 
-                if (namedIndexPropertyName != null && arrayItem.ValueKind == JsonValueKind.Object && arrayItem.TryGetProperty(namedIndexPropertyName, out var namedIndex))
+                (string Path, JsonElement Value)? namedItemOrderResult = null;
+                if (namedIndexPropertyName != null)
                 {
-                    arraySubPath = $"{path}['{namedIndex.GetString()}']";
+                    if (arrayItem.ValueKind == JsonValueKind.Object && arrayItem.TryGetProperty(namedIndexPropertyName, out var namedIndex))
+                    {
+                        if (isOrderSignificant)
+                        {
+                            namedItemOrderResult = (arraySubPath + "." + namedIndexPropertyName, namedIndex);
+                        }
+
+                        arraySubPath = $"{path}['{namedIndex.GetString()}']";
+                    }
                 }
 
-                return FlattenJson(arraySubPath, arrayItem);
+                var flattened = FlattenJson(arraySubPath, arrayItem);
+                if (namedItemOrderResult.HasValue)
+                {
+                    flattened = flattened.Prepend(namedItemOrderResult.Value);
+                }
+                return flattened;
             });
     }
 

--- a/src/PAModel/MsAppTest.cs
+++ b/src/PAModel/MsAppTest.cs
@@ -324,17 +324,22 @@ internal class MsAppTest
         Debug.Assert(path is not null);
         Debug.Assert(jsonArray.ValueKind == JsonValueKind.Array);
 
-        var isRulesArray = path.StartsWith("TopParent.") && path.EndsWith(".Rules");
+        // For some arrays, it's better to use a named sub-property as the indexer when ordering of the items in the array is not significant.
+        var namedIndexPropertyName = path switch
+        {
+            _ when path.StartsWith("TopParent.") && path.EndsWith(".Rules") => "Property",
+            _ when path.StartsWith("TopParent.") && path.EndsWith(".DynamicProperties") => "PropertyName",
+            _ => null
+        };
 
         return jsonArray.EnumerateArray()
             .SelectMany((arrayItem, index) =>
             {
                 var arraySubPath = $"{path}[{index}]";
 
-                // For Rules arrays, use the Property name as the key instead of the index, since order doesn't matter and Property is (likely) unique
-                if (isRulesArray && arrayItem.ValueKind == JsonValueKind.Object && arrayItem.TryGetProperty("Property", out var propertyName))
+                if (namedIndexPropertyName != null && arrayItem.ValueKind == JsonValueKind.Object && arrayItem.TryGetProperty(namedIndexPropertyName, out var namedIndex))
                 {
-                    arraySubPath = $"{path}['{propertyName.GetString()}']";
+                    arraySubPath = $"{path}['{namedIndex.GetString()}']";
                 }
 
                 return FlattenJson(arraySubPath, arrayItem);

--- a/src/PAModel/MsAppTest.cs
+++ b/src/PAModel/MsAppTest.cs
@@ -277,9 +277,9 @@ internal class MsAppTest
         }
     }
 
-    public static Dictionary<string, JsonElement> FlattenJson(byte[] json)
+    public static Dictionary<string, JsonElement> FlattenJson(byte[] json, JsonDocumentOptions options = default)
     {
-        using var document = JsonDocument.Parse(json);
+        using var document = JsonDocument.Parse(json, options);
         return FlattenJson(string.Empty, document.RootElement)
             .ToDictionary(t => t.Path, t => t.Value.Clone());
     }

--- a/src/PAModel/PAConvert/Yaml/YamlLexer.cs
+++ b/src/PAModel/PAConvert/Yaml/YamlLexer.cs
@@ -12,16 +12,16 @@ namespace Microsoft.PowerPlatform.Formulas.Tools.Yaml;
 /// Helper to read our strict subset of Yaml.
 /// Give useful errors on things outside of the subset.
 /// See https://yaml.org/
-/// This will strip '=' signs at the start of single property values. 
+/// This will strip '=' signs at the start of single property values.
 /// </summary>
 internal class YamlLexer : IDisposable
 {
     private const string NewLine = "\n";
 
-    // The actual contents to read. 
+    // The actual contents to read.
     private readonly TextReader _reader;
 
-    // Stack of indentations. 
+    // Stack of indentations.
     private readonly Stack<Indent> _currentIndent;
 
     private YamlToken _lastPair;
@@ -34,7 +34,7 @@ internal class YamlLexer : IDisposable
     private string _currentLineContents;
 
     // Per https://github.com/microsoft/PowerApps-Language-Tooling/issues/115,
-    // We allow comments, but don't round-trip them. Issue a warning. 
+    // We allow comments, but don't round-trip them. Issue a warning.
     public SourceLocation? _commentStrippedWarning;
     private bool _isDisposed;
     public const string MissingSingleQuoteFunctionNode = "Missing closing \' in Function Node";
@@ -48,14 +48,14 @@ internal class YamlLexer : IDisposable
         _currentFileName = filenameHint; // For error reporting
 
         // We pretend the file is wrapped in a "object:" tag.
-        _lastPair = YamlToken.NewStartObj(default, null);
-        _currentIndent = new Stack<Indent>()
-        {
+        _lastPair = YamlToken.NewStartObj(SourceLocation.FromFile(_currentFileName), null);
+        _currentIndent =
+        [
             new() {
-                _oldIndentLevel = -1,
-                _lineStart = 0
+                LineStart = 0,
+                OldIndentLevel = -1,
             }
-        };
+        ];
     }
 
     /// <summary>
@@ -85,7 +85,7 @@ internal class YamlLexer : IDisposable
     }
 
     /// <summary>
-    /// Get the next token in the stream. Returns an EOF at the end of document. 
+    /// Get the next token in the stream. Returns an EOF at the end of document.
     /// </summary>
     /// <returns></returns>
     public YamlToken ReadNext()
@@ -105,12 +105,12 @@ internal class YamlLexer : IDisposable
         //   different indent size
         //   duplicate keys
         //   empty properties (should have an indent)
-        //   no tabs. 
-        //  don't allow --- documents 
+        //   no tabs.
+        //  don't allow --- documents
 
         // Start of line.
         // [Indent] [PropertyName] [Colon]
-        // [Indent] [PropertyName] [Colon] [space] [equals] [VALUE] 
+        // [Indent] [PropertyName] [Colon] [space] [equals] [VALUE]
         // [Indent] [PropertyName] [Colon] [space] [MultilineEscape]
 
         LineParser line;
@@ -134,7 +134,7 @@ internal class YamlLexer : IDisposable
             // get starting indent.
             indentLen = line.EatIndent();
 
-            // Comment indent level doesn't matter - may not match object indent. 
+            // Comment indent level doesn't matter - may not match object indent.
             if (line.Current == '#')
             {
                 // https://github.com/microsoft/PowerApps-Language-Tooling/issues/115
@@ -153,7 +153,7 @@ internal class YamlLexer : IDisposable
                 break;
             }
 
-            // Eat the newline and go to the next line. 
+            // Eat the newline and go to the next line.
             MoveNextLine();
         }
 
@@ -174,7 +174,7 @@ internal class YamlLexer : IDisposable
         // If last was 'start object', then this indent sets the new level,
         if (_lastPair.Kind == YamlTokenKind.StartObj)
         {
-            var lastIndent = _currentIndent.Peek()._oldIndentLevel;
+            var lastIndent = _currentIndent.Peek().OldIndentLevel;
 
             if (indentLen == lastIndent) // Close immediate parent
             {
@@ -183,11 +183,11 @@ internal class YamlLexer : IDisposable
             }
             else if (indentLen < lastIndent)
             {
-                // Close current objects one at a time.                     
+                // Close current objects one at a time.
                 _currentIndent.Pop();
 
-                var prevIndent = _currentIndent.Peek()._oldIndentLevel;
-                // Indent must exactly match a previous one up the stack. 
+                var prevIndent = _currentIndent.Peek().OldIndentLevel;
+                // Indent must exactly match a previous one up the stack.
                 if (indentLen > prevIndent)
                 {
                     return Error(line, "Property indent must align exactly with a previous indent level.");
@@ -201,16 +201,16 @@ internal class YamlLexer : IDisposable
                 // Error. new object should be indented.
                 return Unsupported(line, "Can't have null properties. Line should be indented to start a new property.");
             }
-            _currentIndent.Peek()._newIndentLevel = indentLen;
+            _currentIndent.Peek().NewIndentLevel = indentLen;
         }
         else
         {
             // Subsequent properties should be at same indentation level.
-            var expectedIndent = _currentIndent.Peek()._newIndentLevel;
+            var expectedIndent = _currentIndent.Peek().NewIndentLevel;
             if (indentLen == expectedIndent)
             {
                 // Good. Common case.
-                // Continue processing below to actually parse this property. 
+                // Continue processing below to actually parse this property.
             }
             else if (indentLen > expectedIndent)
             {
@@ -219,13 +219,13 @@ internal class YamlLexer : IDisposable
             else
             {
                 // Closing an object.
-                // Indent must exactly match a previous one up the stack. 
-                if (indentLen > _currentIndent.Peek()._oldIndentLevel)
+                // Indent must exactly match a previous one up the stack.
+                if (indentLen > _currentIndent.Peek().OldIndentLevel)
                 {
                     return Error(line, "Property indent must align exactly with a previous indent level.");
                 }
 
-                // Close current objects one at a time.                     
+                // Close current objects one at a time.
                 _currentIndent.Pop();
                 return YamlToken.EndObj;
             }
@@ -261,9 +261,9 @@ internal class YamlLexer : IDisposable
             }
             line._idx++;
         }
-        line.MaybeEat(':'); // skip colon. 
+        line.MaybeEat(':'); // skip colon.
 
-        // Prop name could have spaces, but no colons. 
+        // Prop name could have spaces, but no colons.
         var propName = line._line.Substring(indentLen, line._idx - indentLen - 1).Trim();
 
         if (requiresClosingDoubleQuote)
@@ -272,7 +272,7 @@ internal class YamlLexer : IDisposable
         }
 
         // If it's a property, must have at least 1 space.
-        // If it's start object, then ignore all spaces. 
+        // If it's start object, then ignore all spaces.
 
         var iSpaces = 0;
         while (line.MaybeEat(' '))
@@ -280,22 +280,21 @@ internal class YamlLexer : IDisposable
             iSpaces++; // skip optional spaces
         }
 
-        YamlToken error;
+        // Detect duplicate property keys at the same level.
+        if (!_currentIndent.Peek().TryRegisterProperty(propName, CurrentLine, out var existingPropLine))
+        {
+            // Key is already present.
+            return YamlToken.NewError(Loc(line), $"Property '{propName}' was already defined on line {existingPropLine}.");
+        }
+
         if (line.Current == 0) // EOL
         {
-            error = _currentIndent.Peek().CheckDuplicate(propName, CurrentLine);
-            if (error != null)
-            {
-                error.Span = Loc(line);
-                return error;
-            }
-
             // New Object.
             // Next line must begin an indent.
             _currentIndent.Push(new Indent
             {
-                _lineStart = CurrentLine,
-                _oldIndentLevel = indentLen
+                LineStart = CurrentLine,
+                OldIndentLevel = indentLen
                 // newIndentLevel will be set at next line
             });
 
@@ -333,7 +332,7 @@ internal class YamlLexer : IDisposable
         {
             // These are common YAml sequences, but extremely problematic and could be user error.
             // Disallow them and force the user to explicit.
-            // Is "hello" a string or identifier? 
+            // Is "hello" a string or identifier?
             //    Foo: "Hello"
             //
             // Instead, have the user write:
@@ -358,11 +357,11 @@ internal class YamlLexer : IDisposable
             }
             else if (line.MaybeEat('+'))
             {
-                multilineMode = 2; // 1+ newlines. 
+                multilineMode = 2; // 1+ newlines.
             }
             else
             {
-                multilineMode = 1; // exactly 1 newline at end. 
+                multilineMode = 1; // exactly 1 newline at end.
             }
 
             iSpaces = 0;
@@ -375,7 +374,7 @@ internal class YamlLexer : IDisposable
             {
                 return UnsupportedComment(line);
             }
-            else if (line.Current != 0) // EOL, catch all error. 
+            else if (line.Current != 0) // EOL, catch all error.
             {
                 return Error(line, "Content for | escape must start on next line.");
             }
@@ -397,7 +396,7 @@ internal class YamlLexer : IDisposable
         }
         else if (Options.HasFlag(YamlLexerOptions.EnforceLeadingEquals))
         {
-            // Warn on legal yaml escapes (>) that we don't support in our subset here. 
+            // Warn on legal yaml escapes (>) that we don't support in our subset here.
             return Error(line, "Expected either '=' for a single line expression or '|' to begin a multiline expression");
         }
         else
@@ -407,19 +406,12 @@ internal class YamlLexer : IDisposable
             MoveNextLine();
         }
 
-        error = _currentIndent.Peek().CheckDuplicate(propName, CurrentLine);
-        if (error != null)
-        {
-            error.Span = Loc(line);
-            return error;
-        }
-
         var endIndex = line._line.Length + 1;
         return YamlToken.NewProperty(LocWorker(startColumn, endIndex), propName, value);
     }
 
 
-    // Errors that are valid yaml, but not in our supported subset. 
+    // Errors that are valid yaml, but not in our supported subset.
     private YamlToken Unsupported(LineParser line, string message)
     {
         return Error(line, message);
@@ -451,7 +443,7 @@ internal class YamlLexer : IDisposable
     }
 
 
-    // For an error at a specific character. 
+    // For an error at a specific character.
     private SourceLocation Loc(LineParser line)
     {
         var columnIdx1 = line._idx + 1;
@@ -461,11 +453,11 @@ internal class YamlLexer : IDisposable
     // For a success case referring to a range.
     private SourceLocation Loc(int startIndex1, LineParser endChar)
     {
-        var endIndex1 = endChar._idx + 1; // convert 0-based to 1-base 
+        var endIndex1 = endChar._idx + 1; // convert 0-based to 1-base
         return LocWorker(startIndex1, endIndex1);
     }
 
-    // 1-based indexes. 
+    // 1-based indexes.
     private SourceLocation LocWorker(int startIndex1, int endIndex1)
     {
         return new SourceLocation(CurrentLine, startIndex1, CurrentLine, endIndex1, _currentFileName);
@@ -479,9 +471,9 @@ internal class YamlLexer : IDisposable
         var sb = new StringBuilder();
 
         // First line establishes indent level.
-        // Yaml allows empty Multilines, we require it must have at least 1 line in it. (no empty values) 
+        // Yaml allows empty Multilines, we require it must have at least 1 line in it. (no empty values)
 
-        var parentIndent = _currentIndent.Peek()._newIndentLevel;
+        var parentIndent = _currentIndent.Peek().NewIndentLevel;
         var thisIndent = -1;
 
         while (true)
@@ -489,12 +481,12 @@ internal class YamlLexer : IDisposable
             var line = PeekLine();
             if (line == null)
             {
-                break; // end of file. 
+                break; // end of file.
             }
             var indentLen = line.EatIndent();
             if (thisIndent == -1)
             {
-                // First line, sets the indent 
+                // First line, sets the indent
                 thisIndent = indentLen;
             }
 
@@ -537,11 +529,11 @@ internal class YamlLexer : IDisposable
         }
         else if (multilineMode == 1)
         {
-            // Just one. This is already the case. 
+            // Just one. This is already the case.
         }
         else if (multilineMode > 1)
         {
-            // Allows multiple. 
+            // Allows multiple.
         }
 
         // End of multiline escape.
@@ -553,7 +545,7 @@ internal class YamlLexer : IDisposable
     [DebuggerDisplay("{DebuggerToString()}")]
     private class LineParser
     {
-        // 0-based character index into line 
+        // 0-based character index into line
         public int _idx;
 
         public readonly string _line;
@@ -563,7 +555,7 @@ internal class YamlLexer : IDisposable
             _line = line;
         }
 
-        // Helper to handle eol. 
+        // Helper to handle eol.
         public char Current
         {
             get
@@ -603,7 +595,7 @@ internal class YamlLexer : IDisposable
         }
 
         // Eat the left indent and return # of spaces in it.
-        // We require spaces and don't allow tabs. 
+        // We require spaces and don't allow tabs.
         public int EatIndent()
         {
             while (MaybeEat(' ')) ;
@@ -620,27 +612,28 @@ internal class YamlLexer : IDisposable
 
     // Indentation levels within the file.
     // These are maintained in a stack.
-    [DebuggerDisplay("Start: {_lineStart}, {_oldIndentLevel}-->{_newIndentLevel}")]
+    [DebuggerDisplay("Start: {LineStart}, {OldIndentLevel}-->{NewIndentLevel}")]
     private class Indent
     {
-        public int _oldIndentLevel;
-        public int _newIndentLevel; // for children of this object. 
-        public int _lineStart; // what line did this indenting start at?
+        public int LineStart { get; init; } // what line did this indenting start at?
+        public int OldIndentLevel { get; init; }
+        public int NewIndentLevel { get; set; } // for children of this object.
 
         // For detecting collisions in previous properties.
         // Collisions must be *case-sensitive*
-        // Map property name to line that it was declared on. 
-        public Dictionary<string, int> _previousProperties = new(StringComparer.Ordinal);
+        // Map property name to line that it was declared on.
+        private readonly Dictionary<string, int> _previousProperties = new(StringComparer.Ordinal);
 
-        internal YamlToken CheckDuplicate(string propName, int currentLine)
+        public bool TryRegisterProperty(string propName, int line, out int existingPropLine)
         {
-            if (_previousProperties.TryGetValue(propName, out var oldLine))
+            if (_previousProperties.TryGetValue(propName, out existingPropLine))
             {
-                // Key is already present.
-                return YamlToken.NewError(default, $"Property was already defined on line {oldLine} and now on line {currentLine}.");
+                return false;
             }
-            _previousProperties.Add(propName, currentLine);
-            return null;
+
+            _previousProperties.Add(propName, line);
+            existingPropLine = -1;
+            return true;
         }
     }
 

--- a/src/PAModel/PAConvert/Yaml/YamlToken.cs
+++ b/src/PAModel/PAConvert/Yaml/YamlToken.cs
@@ -33,7 +33,7 @@ internal class YamlToken
 
     public static YamlToken NewStartObj(SourceLocation span, string name)
     {
-        return new YamlToken
+        return new()
         {
             Kind = YamlTokenKind.StartObj,
             Span = span,
@@ -43,7 +43,7 @@ internal class YamlToken
 
     public static YamlToken NewProperty(SourceLocation span, string name, string value)
     {
-        return new YamlToken
+        return new()
         {
             Kind = YamlTokenKind.Property,
             Span = span,
@@ -55,7 +55,7 @@ internal class YamlToken
 
     public static YamlToken NewError(SourceLocation span, string message)
     {
-        return new YamlToken
+        return new()
         {
             Kind = YamlTokenKind.Error,
             Span = span,
@@ -65,13 +65,12 @@ internal class YamlToken
 
     public override string ToString()
     {
-        switch (Kind)
+        return Kind switch
         {
-            case YamlTokenKind.Property: return $"{Property}={Value}";
-            case YamlTokenKind.StartObj: return $"{Property}:";
-            case YamlTokenKind.Error: return $"Yaml error: {Span.FileName}:{Span.StartLine},{Span.StartChar} {Value}";
-            default:
-                return $"<{Kind}>";
-        }
+            YamlTokenKind.Property => $"{Property}={Value}",
+            YamlTokenKind.StartObj => $"{Property}:",
+            YamlTokenKind.Error => $"Yaml error: {Span.FileName}:{Span.StartLine},{Span.StartChar} {Value}",
+            _ => $"<{Kind}>",
+        };
     }
 }

--- a/src/PAModelTests/ErrorTests.cs
+++ b/src/PAModelTests/ErrorTests.cs
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.IO;
 using Microsoft.PowerPlatform.Formulas.Tools;
 using Microsoft.PowerPlatform.Formulas.Tools.IO;
+using System.IO;
+using System.Text.Json;
 
 namespace PAModelTests;
 
@@ -73,9 +74,15 @@ public class ErrorTests
     [DataRow("simpleRemoved1.json", "simpleRemoved2.json", "simpleRemovedOutput.txt")]
     [DataRow("emptyNestedArray1.json", "emptyNestedArray2.json", "emptyNestedArrayOutput.txt")]
     [DataRow("simpleArray1.json", "simpleArray2.json", "simpleArrayOutput.txt")]
+    [DataRow("rulesChanged1.json", "rulesChanged2.json", "rulesChangedOutput.txt")]
+    [DataRow("dynamicPropertiesChanged1.json", "dynamicPropertiesChanged2.json", "dynamicPropertiesChangedOutput.txt")]
 
     public void TestJSONValueChanged(string file1, string file2, string file3)
     {
+        var jsonOptions = new JsonDocumentOptions()
+        {
+            CommentHandling = JsonCommentHandling.Skip, // so we can add comments in the test files to explain the test case
+        };
 
         var path1 = Path.Combine(Environment.CurrentDirectory, "TestData", file1);
         var path2 = Path.Combine(Environment.CurrentDirectory, "TestData", file2);
@@ -86,8 +93,8 @@ public class ErrorTests
         var jsonString1 = File.ReadAllBytes(path1);
         var jsonString2 = File.ReadAllBytes(path2);
 
-        var jsonDictionary1 = MsAppTest.FlattenJson(jsonString1);
-        var jsonDictionary2 = MsAppTest.FlattenJson(jsonString2);
+        var jsonDictionary1 = MsAppTest.FlattenJson(jsonString1, jsonOptions);
+        var jsonDictionary2 = MsAppTest.FlattenJson(jsonString2, jsonOptions);
 
         // IsMismatched on mismatched files
         MsAppTest.CheckPropertyChangedRemoved(file1, jsonDictionary1, jsonDictionary2, errorContainer);

--- a/src/PAModelTests/ErrorTests.cs
+++ b/src/PAModelTests/ErrorTests.cs
@@ -76,6 +76,7 @@ public class ErrorTests
     [DataRow("simpleArray1.json", "simpleArray2.json", "simpleArrayOutput.txt")]
     [DataRow("rulesChanged1.json", "rulesChanged2.json", "rulesChangedOutput.txt")]
     [DataRow("dynamicPropertiesChanged1.json", "dynamicPropertiesChanged2.json", "dynamicPropertiesChangedOutput.txt")]
+    [DataRow("childrenChanged1.json", "childrenChanged2.json", "childrenChangedOutput.txt")]
 
     public void TestJSONValueChanged(string file1, string file2, string file3)
     {

--- a/src/PAModelTests/TestData/childrenChanged1.json
+++ b/src/PAModelTests/TestData/childrenChanged1.json
@@ -1,0 +1,43 @@
+{
+  "TopParent": {
+    "Screen1": {
+      "Name": "Screen1",
+      "Template": "screen",
+      "Children": [
+        {
+          "Name": "Control1",
+          "Template": "button",
+          "Rules": [
+            {
+              "Property": "Text",
+              "InvariantScript": "\"Button 1\"",
+              "RuleProviderType": "Unknown"
+            }
+          ]
+        },
+        {
+          "Name": "Control2",
+          "Template": "label",
+          "Rules": [
+            {
+              "Property": "Text",
+              "InvariantScript": "\"Label 2\"",
+              "RuleProviderType": "Unknown"
+            }
+          ]
+        },
+        {
+          "Name": "Control3",
+          "Template": "label",
+          "Rules": [
+            {
+              "Property": "Text",
+              "InvariantScript": "\"Label 3\"",
+              "RuleProviderType": "Unknown"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/PAModelTests/TestData/childrenChanged2.json
+++ b/src/PAModelTests/TestData/childrenChanged2.json
@@ -1,0 +1,43 @@
+{
+  "TopParent": {
+    "Screen1": {
+      "Name": "Screen1",
+      "Template": "screen",
+      "Children": [
+        {
+          "Name": "Control2",
+          "Template": "label",
+          "Rules": [
+            {
+              "Property": "Text",
+              "InvariantScript": "\"Label 2\"",
+              "RuleProviderType": "Unknown"
+            }
+          ]
+        },
+        {
+          "Name": "Control1",
+          "Template": "button",
+          "Rules": [
+            {
+              "Property": "Text",
+              "InvariantScript": "\"Button 1 Modified\"",
+              "RuleProviderType": "Unknown"
+            }
+          ]
+        },
+        {
+          "Name": "Control3",
+          "Template": "label",
+          "Rules": [
+            {
+              "Property": "Text",
+              "InvariantScript": "\"Label 3 Modified\"",
+              "RuleProviderType": "Unknown"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/PAModelTests/TestData/childrenChangedOutput.txt
+++ b/src/PAModelTests/TestData/childrenChangedOutput.txt
@@ -1,8 +1,5 @@
 childrenChanged1.json: Error   PA3013: Property Value Changed: TopParent.Screen1.Children[0].Name
-childrenChanged1.json: Error   PA3013: Property Value Changed: TopParent.Screen1.Children[0].Template
-childrenChanged1.json: Error   PA3013: Property Value Changed: TopParent.Screen1.Children[0].Rules['Text'].InvariantScript
+childrenChanged1.json: Error   PA3013: Property Value Changed: TopParent.Screen1.Children['Control1'].Rules['Text'].InvariantScript
 childrenChanged1.json: Error   PA3013: Property Value Changed: TopParent.Screen1.Children[1].Name
-childrenChanged1.json: Error   PA3013: Property Value Changed: TopParent.Screen1.Children[1].Template
-childrenChanged1.json: Error   PA3013: Property Value Changed: TopParent.Screen1.Children[1].Rules['Text'].InvariantScript
-childrenChanged1.json: Error   PA3013: Property Value Changed: TopParent.Screen1.Children[2].Rules['Text'].InvariantScript
-7 errors, 0 warnings.
+childrenChanged1.json: Error   PA3013: Property Value Changed: TopParent.Screen1.Children['Control3'].Rules['Text'].InvariantScript
+4 errors, 0 warnings.

--- a/src/PAModelTests/TestData/childrenChangedOutput.txt
+++ b/src/PAModelTests/TestData/childrenChangedOutput.txt
@@ -1,0 +1,8 @@
+childrenChanged1.json: Error   PA3013: Property Value Changed: TopParent.Screen1.Children[0].Name
+childrenChanged1.json: Error   PA3013: Property Value Changed: TopParent.Screen1.Children[0].Template
+childrenChanged1.json: Error   PA3013: Property Value Changed: TopParent.Screen1.Children[0].Rules['Text'].InvariantScript
+childrenChanged1.json: Error   PA3013: Property Value Changed: TopParent.Screen1.Children[1].Name
+childrenChanged1.json: Error   PA3013: Property Value Changed: TopParent.Screen1.Children[1].Template
+childrenChanged1.json: Error   PA3013: Property Value Changed: TopParent.Screen1.Children[1].Rules['Text'].InvariantScript
+childrenChanged1.json: Error   PA3013: Property Value Changed: TopParent.Screen1.Children[2].Rules['Text'].InvariantScript
+7 errors, 0 warnings.

--- a/src/PAModelTests/TestData/dynamicPropertiesChanged1.json
+++ b/src/PAModelTests/TestData/dynamicPropertiesChanged1.json
@@ -1,0 +1,34 @@
+{
+  "TopParent": {
+    "Canvas1": {
+      "Name": "Canvas1",
+      "Template": "groupContainer",
+      "DynamicProperties": [
+        {
+          "PropertyName": "LayoutX",
+          "Rule": {
+            "Property": "LayoutX",
+            "InvariantScript": "10",
+            "RuleProviderType": "Unknown"
+          }
+        },
+        {
+          "PropertyName": "LayoutY",
+          "Rule": {
+            "Property": "LayoutY",
+            "InvariantScript": "20",
+            "RuleProviderType": "Unknown"
+          }
+        },
+        {
+          "PropertyName": "LayoutWidth",
+          "Rule": {
+            "Property": "LayoutWidth",
+            "InvariantScript": "640",
+            "RuleProviderType": "Unknown"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/PAModelTests/TestData/dynamicPropertiesChanged2.json
+++ b/src/PAModelTests/TestData/dynamicPropertiesChanged2.json
@@ -1,0 +1,36 @@
+{
+  "TopParent": {
+    "Canvas1": {
+      "Name": "Canvas1",
+      "Template": "groupContainer",
+      "DynamicProperties": [
+        {
+          // out of order and InvariantScript changed
+          "PropertyName": "LayoutY",
+          "Rule": {
+            "Property": "LayoutY",
+            "InvariantScript": "30",
+            "RuleProviderType": "Unknown"
+          }
+        },
+        {
+          // order changed, but doesn't produce error
+          "PropertyName": "LayoutX",
+          "Rule": {
+            "Property": "LayoutX",
+            "InvariantScript": "10",
+            "RuleProviderType": "Unknown"
+          }
+        },
+        {
+          "PropertyName": "LayoutWidth",
+          "Rule": {
+            "Property": "LayoutWidth",
+            "InvariantScript": "640",
+            "RuleProviderType": "Unknown"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/PAModelTests/TestData/dynamicPropertiesChangedOutput.txt
+++ b/src/PAModelTests/TestData/dynamicPropertiesChangedOutput.txt
@@ -1,0 +1,2 @@
+dynamicPropertiesChanged1.json: Error   PA3013: Property Value Changed: TopParent.Canvas1.DynamicProperties['LayoutY'].Rule.InvariantScript
+1 errors, 0 warnings.

--- a/src/PAModelTests/TestData/rulesChanged1.json
+++ b/src/PAModelTests/TestData/rulesChanged1.json
@@ -1,0 +1,25 @@
+{
+  "TopParent": {
+    "Screen1": {
+      "Name": "Screen1",
+      "Template": "screen",
+      "Rules": [
+        {
+          "Property": "Fill",
+          "InvariantScript": "RGBA(255, 0, 0, 1)",
+          "RuleProviderType": "Unknown"
+        },
+        {
+          "Property": "Text",
+          "InvariantScript": "\"Hello World\"",
+          "RuleProviderType": "Unknown"
+        },
+        {
+          "Property": "Width",
+          "InvariantScript": "1024",
+          "RuleProviderType": "Unknown"
+        }
+      ]
+    }
+  }
+}

--- a/src/PAModelTests/TestData/rulesChanged2.json
+++ b/src/PAModelTests/TestData/rulesChanged2.json
@@ -1,0 +1,26 @@
+{
+  "TopParent": {
+    "Screen1": {
+      "Name": "Screen1",
+      "Template": "screen",
+      "Rules": [
+        {
+          "Property": "Text",
+          "InvariantScript": "\"Hello World\"",
+          "RuleProviderType": "Unknown"
+        },
+        // changed and out of order
+        {
+          "Property": "Fill",
+          "InvariantScript": "RGBA(0, 0, 255, 1)",
+          "RuleProviderType": "Unknown"
+        },
+        {
+          "Property": "Width",
+          "InvariantScript": "1024",
+          "RuleProviderType": "Unknown"
+        }
+      ]
+    }
+  }
+}

--- a/src/PAModelTests/TestData/rulesChangedOutput.txt
+++ b/src/PAModelTests/TestData/rulesChangedOutput.txt
@@ -1,0 +1,2 @@
+rulesChanged1.json: Error   PA3013: Property Value Changed: TopParent.Screen1.Rules['Fill'].InvariantScript
+1 errors, 0 warnings.

--- a/src/PAModelTests/YamlTest.cs
+++ b/src/PAModelTests/YamlTest.cs
@@ -157,33 +157,34 @@ Obj1:
     // Error on 1st token read
     [TestMethod]
     [DataRow("Foo: 12")] // missing =
-    [DataRow("Foo: |\r\n=12")] // missing = in newline
+    [DataRow("Foo: |\r\n=12", 2)] // missing = in newline
     [DataRow("Foo: =x #comment")] // comments not allowed in single line.
     [DataRow("Foo: |x\n  =next")] // chars on same line after |
     [DataRow("Foo: >\n  =next")] // > multiline not supported
-    [DataRow("Foo: |\nBar: =next")] // empty multiline
+    [DataRow("Foo: |\nBar: =next", 2)] // empty multiline
     [DataRow("'Foo: \n Bar:")] // unclosed \' escape
     [DataRow("---")] // multi docs not supported
-    public void ExpectedError(string expr)
+    public void ExpectedError(string expr, int expectedLine = 1)
     {
         using var sr = new StringReader(expr);
-        using var y = new YamlLexer(sr);
+        using var y = new YamlLexer(sr, "expr.fx.yaml");
 
-        AssertLexError(y);
+        AssertLexError(y, expectedLine, expectedFileName: "expr.fx.yaml");
+
     }
 
     // Error on 2nd token read. 
     [TestMethod]
-    [DataRow("Foo:\r\n  val\r\n")] // Must have escape if there's a newline
-    public void ExpectedError2(string expr)
+    [DataRow("Foo:\r\n  val\r\n", 2)] // Must have escape if there's a newline
+    public void ExpectedError2(string expr, int expectedLine)
     {
         using var sr = new StringReader(expr);
-        using var y = new YamlLexer(sr);
+        using var y = new YamlLexer(sr, "expr.fx.yaml");
 
         var tokenOk = y.ReadNext();
-        Assert.AreNotEqual(YamlTokenKind.Error, tokenOk.Kind);
+        tokenOk.Kind.Should().NotBe(YamlTokenKind.Error);
 
-        AssertLexError(y);
+        AssertLexError(y, expectedLine, expectedFileName: "expr.fx.yaml");
     }
 
     // Yaml ignores duplicate properties. This could lead to data loss!
@@ -200,7 +201,7 @@ P2: =456
 P1: =duplicate!
 ";
         using var sr = new StringReader(text);
-        using var y = new YamlLexer(sr);
+        using var y = new YamlLexer(sr, filenameHint: "testCase.fx.yaml");
 
         AssertLex("P1=123", y);
         AssertLex("Obj1:", y);
@@ -209,7 +210,7 @@ P1: =duplicate!
         AssertLex("p1=Casing Different, not duplicate", y);
         AssertLex("P2=456", y);
 
-        AssertLexError(y);
+        AssertLexError(y, expectedLine: 6, expectedFileName: "testCase.fx.yaml");
     }
 
     [TestMethod]
@@ -377,12 +378,12 @@ Obj1:
  ErrorObj3:
 ";
         using var sr = new StringReader(text);
-        using var y = new YamlLexer(sr);
+        using var y = new YamlLexer(sr, "test.yaml");
 
         AssertLex("P0=1", y);
         AssertLex("Obj1:", y);
         AssertLex("Obj2:", y);
-        AssertLexError(y); // Obj3 is at a bad indent. 
+        AssertLexError(y, expectedLine: 4, expectedFileName: "test.yaml"); // Obj3 is at a bad indent. 
     }
 
     [TestMethod]
@@ -492,51 +493,6 @@ P2: = ""hello"" & ""world""
         Assert.AreEqual(expectedYaml, writer.ToString());
     }
 
-
-    #region Helpers
-    private static void AssertLexEndFile(YamlLexer y)
-    {
-        AssertLex("<EndOfFile>", y);
-    }
-
-    private static void AssertLexEndObj(YamlLexer y)
-    {
-        AssertLex("<EndObj>", y);
-    }
-
-    private static void AssertLexError(YamlLexer y)
-    {
-        var p = y.ReadNext();
-        Assert.AreEqual(YamlTokenKind.Error, p.Kind);
-    }
-
-    private static void AssertLex(string expected, YamlLexer y)
-    {
-        var p = y.ReadNext();
-        Assert.AreEqual(NormNewlines(expected), p.ToString());
-    }
-
-    private static void AssertLex(string expected, YamlLexer y, string sourceSpan)
-    {
-        var p = y.ReadNext();
-        Assert.AreEqual(expected, p.ToString());
-        Assert.AreEqual(sourceSpan, p.Span.ToString());
-    }
-
-    // Parse a single property "Foo" expression with YamlDotNet. 
-    private static string ParseSinglePropertyViaYamlDotNot(string text)
-    {
-        var deserializer = new DeserializerBuilder().Build();
-        var o2 = (Dictionary<object, object>)deserializer.Deserialize(new StringReader(text));
-        var val = (string)o2["Foo"];
-        // Strip the '=' that we add.
-        if (val[0] == '=')
-        {
-            val = val.Substring(1);
-        }
-        return val;
-    }
-
     [TestMethod]
     public void MissingClosingQuoteComponentError()
     {
@@ -624,19 +580,68 @@ P2: = ""hello"" & ""world""
         AssertLexErrorMessage(y, YamlLexer.MissingSingleQuoteProperty);
     }
 
+    #region Helpers
+    private static void AssertLexEndFile(YamlLexer y)
+    {
+        AssertLex("<EndOfFile>", y);
+    }
+
+    private static void AssertLexEndObj(YamlLexer y)
+    {
+        AssertLex("<EndObj>", y);
+    }
+
+    private static void AssertLexError(YamlLexer y, int? expectedLine = null, string expectedFileName = null)
+    {
+        var nextToken = y.ReadNext();
+        nextToken.Kind.Should().Be(YamlTokenKind.Error);
+        if (expectedLine.HasValue)
+        {
+            nextToken.Span.StartLine.Should().Be(expectedLine.Value);
+        }
+        if (expectedFileName != null)
+        {
+            nextToken.Span.FileName.Should().Be(expectedFileName);
+        }
+    }
+
     private static void AssertLexErrorMessage(YamlLexer y, string expectedErrorMessage)
     {
         var p = y.ReadNext();
-        while (p.Kind != YamlTokenKind.EndOfFile)
+        while (p.Kind is not (YamlTokenKind.EndOfFile or YamlTokenKind.Error))
         {
-            if (p.Kind == YamlTokenKind.Error)
-            {
-                Assert.AreEqual(expectedErrorMessage, p.Value);
-                return;
-            }
             p = y.ReadNext();
         }
-        Assert.Fail();
+
+        p.Kind.Should().Be(YamlTokenKind.Error);
+        p.Value.Should().Be(expectedErrorMessage);
+    }
+
+    private static void AssertLex(string expected, YamlLexer y)
+    {
+        var p = y.ReadNext();
+        Assert.AreEqual(NormNewlines(expected), p.ToString());
+    }
+
+    private static void AssertLex(string expected, YamlLexer y, string sourceSpan)
+    {
+        var p = y.ReadNext();
+        Assert.AreEqual(expected, p.ToString());
+        Assert.AreEqual(sourceSpan, p.Span.ToString());
+    }
+
+    // Parse a single property "Foo" expression with YamlDotNet. 
+    private static string ParseSinglePropertyViaYamlDotNot(string text)
+    {
+        var deserializer = new DeserializerBuilder().Build();
+        var o2 = (Dictionary<object, object>)deserializer.Deserialize(new StringReader(text));
+        var val = (string)o2["Foo"];
+        // Strip the '=' that we add.
+        if (val[0] == '=')
+        {
+            val = val.Substring(1);
+        }
+        return val;
     }
 
     #endregion


### PR DESCRIPTION
Addresses unhelpful error messages reported in the following issues:
- #804 
- #803 

Also, made 'Children' indexing better by using control names, but still ensuring that Children ordering in the array is significant.
The result here is less errors being reported when differ only by ordering.