### PR TITLE
Configure CI workflow perms

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/PowerApps-Tooling/security/code-scanning/5](https://github.com/microsoft/PowerApps-Tooling/security/code-scanning/5)

Add an explicit workflow-level `permissions` block in `.github/workflows/CI.yml` so all jobs inherit least-privilege token access unless overridden.  
Best minimal fix (without changing functionality): add:

- `permissions:`
  - `contents: read`

Place it near the top-level keys (after `on:` block and before `jobs:` is the clearest location). No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
