### PR TITLE
Add ControlStyles to PaModule YAML persistence

### DIFF
--- a/src/Persistence.Tests/PaYaml/Serialization/PaYamlSerializerTests.cs
+++ b/src/Persistence.Tests/PaYaml/Serialization/PaYamlSerializerTests.cs
@@ -29,6 +29,47 @@ public class PaYamlSerializerTests : VSTestBase
         paModule.App.Properties.Should().ContainName("Bar").WhoseNamedObject.Start.Should().Be(new(4, 9));
     }
 
+    [TestMethod]
+    public void DeserializeControlStyles()
+    {
+        var paModule = PaYamlSerializer.Deserialize<PaModule>("""
+            ControlStyles:
+              PrimaryButton:
+                Control: Button
+                Properties:
+                  Fill: =Color.Blue
+              Emphasis:
+                Control: Label
+                Properties:
+                  Color: =Color.Red
+            """);
+
+        paModule.ShouldNotBeNull();
+        paModule.ControlStyles.ShouldNotBeNull();
+        paModule.ControlStyles.Should().HaveCount(2);
+
+        // Each style is keyed by its (unique) name and targets a single control type.
+        paModule.ControlStyles["PrimaryButton"].ControlType.Should().Be("Button");
+        paModule.ControlStyles["PrimaryButton"].Properties.Should().ContainName("Fill");
+
+        paModule.ControlStyles["Emphasis"].ControlType.Should().Be("Label");
+        paModule.ControlStyles["Emphasis"].Properties.Should().ContainName("Color");
+
+        // Round-trips back to equivalent YAML.
+        var roundTrippedYaml = PaYamlSerializer.Serialize(paModule);
+        roundTrippedYaml.Should().BeYamlEquivalentTo("""
+            ControlStyles:
+              PrimaryButton:
+                Control: Button
+                Properties:
+                  Fill: =Color.Blue
+              Emphasis:
+                Control: Label
+                Properties:
+                  Color: =Color.Red
+            """);
+    }
+
     #region Deserialize Examples
 
     [TestMethod]
@@ -193,6 +234,7 @@ public class PaYamlSerializerTests : VSTestBase
     [DataRow(@"_TestData/SchemaV3_0/FullSchemaUses/Screens-general-controls.pa.yaml")]
     [DataRow(@"_TestData/SchemaV3_0/FullSchemaUses/Screens-with-components.pa.yaml")]
     [DataRow(@"_TestData/SchemaV3_0/FullSchemaUses/Themes.pa.yaml")]
+    [DataRow(@"_TestData/SchemaV3_0/FullSchemaUses/ControlStyles.pa.yaml")]
     [DataRow(@"_TestData/SchemaV3_0/Examples/Src/DataSources/Dataversedatasources1.pa.yaml")]
     [DataRow(@"_TestData/SchemaV3_0/Examples/Src/_EditorState.pa.yaml")]
     public void RoundTripFromYaml(string path)

--- a/src/Persistence/PaYaml/Models/SchemaV3/ControlStyleDefinition.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/ControlStyleDefinition.cs
@@ -16,14 +16,6 @@ namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV3;
 /// </remarks>
 public record ControlStyleDefinition
 {
-    public ControlStyleDefinition() { }
-
-    [SetsRequiredMembers]
-    public ControlStyleDefinition(string controlType)
-    {
-        ControlType = controlType ?? throw new ArgumentNullException(nameof(controlType));
-    }
-
     /// <summary>
     /// The target control type that this style applies to (e.g. "Button"). Matches <see cref="ControlInstance.ControlType"/>.
     /// </summary>

--- a/src/Persistence/PaYaml/Models/SchemaV3/ControlStyleDefinition.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/ControlStyleDefinition.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.PowerFx;
+using YamlDotNet.Serialization;
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV3;
+
+/// <summary>
+/// Represents a reusable control style that can be applied to controls of a specific type.
+/// </summary>
+/// <remarks>
+/// A control style is identified by its name, which is unique within the containing <see cref="PaModule.ControlStyles"/> mapping.
+/// Each style applies only to the single target control type specified by <see cref="ControlType"/>.
+/// </remarks>
+public record ControlStyleDefinition
+{
+    public ControlStyleDefinition() { }
+
+    [SetsRequiredMembers]
+    public ControlStyleDefinition(string controlType)
+    {
+        ControlType = controlType ?? throw new ArgumentNullException(nameof(controlType));
+    }
+
+    /// <summary>
+    /// The target control type that this style applies to (e.g. "Button"). Matches <see cref="ControlInstance.ControlType"/>.
+    /// </summary>
+    [property: YamlMember(Alias = "Control")]
+    public required string? ControlType { get; init; }
+
+    /// <summary>
+    /// The set of property formulas defined by this style.
+    /// </summary>
+    public NamedObjectMapping<PFxExpressionYaml>? Properties { get; init; }
+}

--- a/src/Persistence/PaYaml/Models/SchemaV3/ControlStyleDefinition.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/ControlStyleDefinition.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.PowerFx;
 using YamlDotNet.Serialization;
 

--- a/src/Persistence/PaYaml/Models/SchemaV3/PaModule.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/PaModule.cs
@@ -19,4 +19,6 @@ public record PaModule
     public EditorStateInstance? EditorState { get; init; }
 
     public NamedObjectMapping<ThemeDefinition>? Themes { get; init; }
+
+    public NamedObjectMapping<ControlStyleDefinition>? ControlStyles { get; init; }
 }

--- a/src/schemas-tests/pa-yaml/v3.0/FullSchemaUses/ControlStyles.pa.yaml
+++ b/src/schemas-tests/pa-yaml/v3.0/FullSchemaUses/ControlStyles.pa.yaml
@@ -1,0 +1,18 @@
+ControlStyles:
+  PrimaryButton:
+    Control: Button
+    Properties:
+      Fill: =Color.Blue
+      Color: =Color.White
+      BorderThickness: =2
+
+  Emphasis:
+    Control: Label@1.2.3
+    Properties:
+      Color: =Color.Red
+      Bold: =true
+
+  SubtleLabel:
+    Control: Label
+    Properties:
+      Color: =Color.Gray


### PR DESCRIPTION
## Summary
Adds YAML persistence modeling for **Control Styles** to the Persistence library (SchemaV3 / PaYamlV3 `Source Code` schema).

A control style is a reusable, named set of property formulas that applies to a single target control type. Each style is identified by a unique name within the module.

## Changes
- New `ControlStyleDefinition` record (`Control` target type + `Properties` formula map).
- New `ControlStyles` property on `PaModule`, modeled as a name-keyed `NamedObjectMapping<ControlStyleDefinition>` (unique style names; duplicate-key checking on deserialize).
- Round-trip serialization test + sample `ControlStyles.pa.yaml` under FullSchemaUses.

## YAML shape
```yaml
ControlStyles:
  PrimaryButton:
    Control: Button
    Properties:
      Fill: =Color.Blue
```
Work item: AB#38567538
